### PR TITLE
Remove health and liveness probes

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
@@ -58,18 +58,8 @@ spec:
           - name: NO_PROXY
             value: {{ .Values.global.proxyConfig.NO_PROXY }}
           {{- end }}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          failureThreshold: 3
-          periodSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          failureThreshold: 3
-          periodSeconds: 10
+        livenessProbe: null
+        readinessProbe: null
         resources: {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -117,18 +107,8 @@ spec:
           - name: NO_PROXY
             value: {{ .Values.global.proxyConfig.NO_PROXY }}
           {{- end }}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8082
-          failureThreshold: 3
-          periodSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8082
-          failureThreshold: 3
-          periodSeconds: 10
+        livenessProbe: null
+        readinessProbe: null
         resources: {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
When API discovery is slow (for various reasons), the controller-runtime
manager will be slow to start. Since that manager runs these probes, k8s
will see the containers as unready/healthy and restart them, but this
does not help the situation - they just go into CrashLoopBackOff.

These probes are unnecessary - other addons (including the config-
policy-controller) do not have them and have not had issues. Removing
them is a simpler solution than trying to tune the timeouts.

Refs:
 - https://github.com/stolostron/backlog/issues/22656
 - https://github.com/stolostron/backlog/issues/23874

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>