### PR TITLE
Fix an issue when deploying the Config Policy controller on OCP 3.11

### DIFF
--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/service.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/service.yaml
@@ -14,6 +14,8 @@ metadata:
     addon.open-cluster-management.io/hosted-manifest-location: hosting
   annotations:
     {{- if eq .Values.kubernetesDistribution "OpenShift" }}
+    # The alpha annotation is required for OpenShift 3.11
+    service.alpha.openshift.io/serving-cert-secret-name: {{ include "controller.fullname" . }}-metrics
     service.beta.openshift.io/serving-cert-secret-name: {{ include "controller.fullname" . }}-metrics
     {{- end }}
 spec:


### PR DESCRIPTION
The `service.beta.openshift.io/serving-cert-secret-name` isn't supported
on OpenShift 3.11 and so
`service.alpha.openshift.io/serving-cert-secret-name` must also be
included.

Relates:
https://github.com/stolostron/backlog/issues/24674