### PR TITLE
Use the consolidated sync controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,9 +272,7 @@ e2e-run-instrumented: e2e-build-instrumented
 	-KUBECONFIG=$(KIND_KUBECONFIG) kubectl create ns $(CONTROLLER_NAMESPACE)
 	CONFIG_POLICY_CONTROLLER_IMAGE="$(REGISTRY)/config-policy-controller:$(TAG)" \
 	  KUBE_RBAC_PROXY_IMAGE="registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.10" \
-	  GOVERNANCE_POLICY_SPEC_SYNC_IMAGE="$(REGISTRY)/governance-policy-spec-sync:$(TAG)" \
-	  GOVERNANCE_POLICY_STATUS_SYNC_IMAGE="$(REGISTRY)/governance-policy-status-sync:$(TAG)" \
-	  GOVERNANCE_POLICY_TEMPLATE_SYNC_IMAGE="$(REGISTRY)/governance-policy-template-sync:$(TAG)" \
+	  GOVERNANCE_POLICY_FRAMEWORK_ADDON_IMAGE="$(REGISTRY)/governance-policy-framework-addon:$(TAG)" \
 	  ./build/_output/bin/$(IMG)-instrumented -test.v -test.run="^TestRunMain$$" -test.coverprofile=$(COVERAGE_E2E_OUT) \
 	  --kubeconfig="$(KIND_KUBECONFIG)" &>build/_output/controller.log &
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ The addons managed by this controller are:
 - The "config-policy-controller" consisting of the
   [Configuration Policy Controller](https://github.com/open-cluster-management-io/config-policy-controller).
 - The "governance-policy-framework" consisting of the
-  [Policy Spec Sync](https://github.com/open-cluster-management-io/governance-policy-spec-sync), the
-  [Policy Status Sync](https://github.com/open-cluster-management-io/governance-policy-status-sync), and the
-  [Policy Template Sync](https://github.com/open-cluster-management-io/governance-policy-template-sync).
+  [Governance Policy Framework Addon](https://github.com/open-cluster-management-io/governance-policy-framework-addon).
 
 Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved.
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,12 +42,8 @@ spec:
           value: quay.io/open-cluster-management/config-policy-controller:latest
         - name: KUBE_RBAC_PROXY_IMAGE
           value: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.10
-        - name: GOVERNANCE_POLICY_SPEC_SYNC_IMAGE
-          value: quay.io/open-cluster-management/governance-policy-spec-sync:latest
-        - name: GOVERNANCE_POLICY_STATUS_SYNC_IMAGE
-          value: quay.io/open-cluster-management/governance-policy-status-sync:latest
-        - name: GOVERNANCE_POLICY_TEMPLATE_SYNC_IMAGE
-          value: quay.io/open-cluster-management/governance-policy-template-sync:latest
+        - name: GOVERNANCE_POLICY_FRAMEWORK_ADDON_IMAGE
+          value: quay.io/open-cluster-management/governance-policy-framework-addon:latest
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/pkg/addon/policyframework/agent_addon.go
+++ b/pkg/addon/policyframework/agent_addon.go
@@ -47,9 +47,7 @@ func getValues(cluster *clusterv1.ManagedCluster,
 			ImagePullPolicy: "IfNotPresent",
 			ImagePullSecret: "open-cluster-management-image-pull-credentials",
 			ImageOverrides: map[string]string{
-				"governance_policy_spec_sync":     os.Getenv("GOVERNANCE_POLICY_SPEC_SYNC_IMAGE"),
-				"governance_policy_status_sync":   os.Getenv("GOVERNANCE_POLICY_STATUS_SYNC_IMAGE"),
-				"governance_policy_template_sync": os.Getenv("GOVERNANCE_POLICY_TEMPLATE_SYNC_IMAGE"),
+				"governance_policy_framework_addon": os.Getenv("GOVERNANCE_POLICY_FRAMEWORK_ADDON_IMAGE"),
 			},
 			NodeSelector: map[string]string{},
 			ProxyConfig: map[string]string{

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
@@ -30,113 +30,35 @@ spec:
         heritage: {{ .Release.Service }}
     spec:
       containers:
-      {{- if not .Values.onMulticlusterHub }}
-      - name: spec-sync
-        image: "{{ .Values.global.imageOverrides.governance_policy_spec_sync }}"
+      - name: governance-policy-framework-addon
+        image: "{{ .Values.global.imageOverrides.governance_policy_framework_addon }}"
         imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
-        command: ["governance-policy-spec-sync"]
-        args:
-          - '--hub-cluster-configfile=/var/run/klusterlet/kubeconfig'
-          - '--health-probe-bind-address=:8081'
-          {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
-          - --legacy-leader-elect=true
-          {{- end }}
-          - --log-encoder={{ .Values.args.logEncoder }}
-          - --log-level={{ .Values.args.logLevel }}
-          - --v={{ .Values.args.pkgLogLevel }}
-          {{- if eq .Values.installMode "Hosted" }}
-          - --target-namespace={{ .Release.Namespace }}
-          {{- end }}
-        env:
-          - name: WATCH_NAMESPACE
-            value: {{ .Values.clusterName }}
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: OPERATOR_NAME
-            value: "governance-policy-spec-sync"
-          {{- if .Values.global.proxyConfig }}
-          - name: HTTP_PROXY
-            value: {{ .Values.global.proxyConfig.HTTP_PROXY }}
-          - name: HTTPS_PROXY
-            value: {{ .Values.global.proxyConfig.HTTPS_PROXY }}
-          - name: NO_PROXY
-            value: {{ .Values.global.proxyConfig.NO_PROXY }}
-          {{- end }}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          failureThreshold: 3
-          periodSeconds: 10
-          {{- if semverCompare "< 1.20.0" .Capabilities.KubeVersion.Version }}
-          initialDelaySeconds: 300
-          {{- end }}
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          failureThreshold: 3
-          periodSeconds: 10
-          {{- if semverCompare "< 1.20.0" .Capabilities.KubeVersion.Version }}
-          initialDelaySeconds: 300
-          {{- end }}
-        {{- if semverCompare ">= 1.20.0" .Capabilities.KubeVersion.Version }}
-        {{- /* startupProbe became stable in k8s 1.20 */}}
-        startupProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          failureThreshold: 30
-          periodSeconds: 10
-        {{- end }}
-        resources: {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          privileged: false
-          readOnlyRootFilesystem: true
-        volumeMounts:
-          - name: klusterlet-config
-            mountPath: /var/run/klusterlet
-      {{- end }}
-      - name: status-sync
-        image: "{{ .Values.global.imageOverrides.governance_policy_status_sync }}"
-        imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
-        command: ["governance-policy-status-sync"]
+        command: ["governance-policy-framework-addon"]
         args:
           - '--enable-lease=true'
           - '--hub-cluster-configfile=/var/run/klusterlet/kubeconfig'
-          - '--health-probe-bind-address=:8082'
           {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
           - --legacy-leader-elect=true
           {{- end }}
           - --log-encoder={{ .Values.args.logEncoder }}
           - --log-level={{ .Values.args.logLevel }}
           - --v={{ .Values.args.pkgLogLevel }}
+          {{- if .Values.onMulticlusterHub }}
+          - --disable-spec-sync=true
+          {{- end }}
           {{- if eq .Values.installMode "Hosted" }}
+          - --cluster-namespace={{ .Release.Namespace }}
+          - --cluster-namespace-on-hub={{ .Values.clusterName }}
+          {{- else }}
           - --cluster-namespace={{ .Values.clusterName }}
           {{- end }}
         env:
-          - name: WATCH_NAMESPACE
-            {{- if eq .Values.installMode "Hosted" }}
-            value: {{ .Release.Namespace }}
-            {{- else }}
-            value: {{ .Values.clusterName }}
-            {{- end }}
           - name: POD_NAME
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
           - name: OPERATOR_NAME
-            value: "governance-policy-status-sync"
-          {{- if .Values.onMulticlusterHub }}
-          - name: ON_MULTICLUSTERHUB
-            value: "true"
-          {{- end }}
+            value: "governance-policy-framework-addon"
           {{- if .Values.global.proxyConfig }}
           - name: HTTP_PROXY
             value: {{ .Values.global.proxyConfig.HTTP_PROXY }}
@@ -148,7 +70,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8082
+            port: 8080
           failureThreshold: 3
           periodSeconds: 10
           {{- if semverCompare "< 1.20.0" .Capabilities.KubeVersion.Version }}
@@ -157,7 +79,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8082
+            port: 8080
           failureThreshold: 3
           periodSeconds: 10
           {{- if semverCompare "< 1.20.0" .Capabilities.KubeVersion.Version }}
@@ -168,7 +90,7 @@ spec:
         startupProbe:
           httpGet:
             path: /readyz
-            port: 8082
+            port: 8080
           failureThreshold: 30
           periodSeconds: 10
         {{- end }}
@@ -183,74 +105,6 @@ spec:
         volumeMounts:
           - name: klusterlet-config
             mountPath: /var/run/klusterlet
-      - name: template-sync
-        image: "{{ .Values.global.imageOverrides.governance_policy_template_sync }}"
-        imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
-        command: ["governance-policy-template-sync"]
-        args:
-          {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
-          - --legacy-leader-elect=true
-          {{- end }}
-          - --log-encoder={{ .Values.args.logEncoder }}
-          - --log-level={{ .Values.args.logLevel }}
-          - --v={{ .Values.args.pkgLogLevel }}
-          - --health-probe-bind-address=:8083
-        env:
-          - name: WATCH_NAMESPACE
-            {{- if eq .Values.installMode "Hosted" }}
-            value: {{ .Release.Namespace }}
-            {{- else }}
-            value: {{ .Values.clusterName }}
-            {{- end }}
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: OPERATOR_NAME
-            value: "governance-policy-template-sync"
-          {{- if .Values.global.proxyConfig }}
-          - name: HTTP_PROXY
-            value: {{ .Values.global.proxyConfig.HTTP_PROXY }}
-          - name: HTTPS_PROXY
-            value: {{ .Values.global.proxyConfig.HTTPS_PROXY }}
-          - name: NO_PROXY
-            value: {{ .Values.global.proxyConfig.NO_PROXY }}
-          {{- end }}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8083
-          failureThreshold: 3
-          periodSeconds: 10
-          {{- if semverCompare "< 1.20.0" .Capabilities.KubeVersion.Version }}
-          initialDelaySeconds: 300
-          {{- end }}
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8083
-          failureThreshold: 3
-          periodSeconds: 10
-          {{- if semverCompare "< 1.20.0" .Capabilities.KubeVersion.Version }}
-          initialDelaySeconds: 300
-          {{- end }}
-        {{- if semverCompare ">= 1.20.0" .Capabilities.KubeVersion.Version }}
-        {{- /* startupProbe became stable in k8s 1.20 */}}
-        startupProbe:
-          httpGet:
-            path: /readyz
-            port: 8083
-          failureThreshold: 30
-          periodSeconds: 10
-        {{- end }}
-        resources: {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          privileged: false
-          readOnlyRootFilesystem: true
       volumes:
         - name: klusterlet-config
           secret:

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/leader_election_role.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/leader_election_role.yaml
@@ -44,11 +44,3 @@ rules:
   verbs:
   - create
   - patch
-# Used for the health check by status-sync
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list

--- a/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
@@ -37,9 +37,7 @@ global:
   imagePullPolicy: IfNotPresent
   imagePullSecret: open-cluster-management-image-pull-credentials
   imageOverrides: 
-    governance_policy_spec_sync: quay.io/open-cluster-management/governance-policy-spec-sync:latest
-    governance_policy_status_sync: quay.io/open-cluster-management/governance-policy-status-sync:latest
-    governance_policy_template_sync: quay.io/open-cluster-management/governance-policy-template-sync:latest
+    governance_policy_framework_addon: quay.io/open-cluster-management/governance-policy-framework-addon:latest
   nodeSelector: {}
   proxyConfig:
     HTTP_PROXY: null


### PR DESCRIPTION
This uses the new governance-policy-framework-addon controller which replaces the separate containers for spec-sync, status-sync, and template-sync.

Relates:
https://github.com/stolostron/backlog/issues/25999