### PR TITLE
Disable leader election when the replicas are set to 1

### DIFF
--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -58,6 +58,9 @@ spec:
         args:
           - "--enable-lease=true"
           - "--cluster-name={{ .Values.clusterName }}"
+          {{- if eq (.Values.replicas | int) 1 }}
+          - '--leader-elect=false'
+          {{- end }}
           {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
           - --legacy-leader-elect=true
           {{- end }}

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
         args:
           - '--enable-lease=true'
           - '--hub-cluster-configfile=/var/run/klusterlet/kubeconfig'
+          {{- if eq (.Values.replicas | int) 1 }}
+          - '--leader-elect=false'
+          {{- end }}
           {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
           - --legacy-leader-elect=true
           {{- end }}

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Test framework deployment", func() {
 
 			checkContainersAndAvailability(cluster, i+1)
 
-			expectedArgs := []string{"--cluster-namespace=" + cluster.clusterName}
+			expectedArgs := []string{"--cluster-namespace=" + cluster.clusterName, "--leader-elect=false"}
 
 			if cluster.clusterType == "hub" {
 				expectedArgs = append(expectedArgs, "--disable-spec-sync=true")

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -263,6 +263,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 						g.Expect(args).To(ContainElement("--log-level=8"))
 						g.Expect(args).To(ContainElement("--v=6"))
 						g.Expect(args).To(ContainElement("--evaluation-concurrency=5"))
+						g.Expect(args).To(ContainElement("--leader-elect=false"))
 					}
 				}
 			}, 180, 10).Should(Succeed())


### PR DESCRIPTION
The addons have the deployment strategy of "Recreate", so leader election is not applicable when the replicas are set to 1. In this case, leader election is disabled to reduce resource utilization on the Kubernetes API server.

Relates:
https://github.com/stolostron/backlog/issues/26711
https://issues.redhat.com/browse/ACM-1867

Signed-off-by: mprahl <mprahl@users.noreply.github.com>