### PR TITLE
Sync policy CRD

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
@@ -267,6 +267,19 @@ spec:
                   description: PolicyDependencies that apply to each template in this Policy
                   items:
                     description: Each PolicyDepenency defines an object reference which must be in a certain compliance state before the policy should be created.
+                    oneOf:
+                      - properties:
+                          kind:
+                            enum:
+                              - CertificatePolicy
+                              - ConfigurationPolicy
+                              - IamPolicy
+                          namespace:
+                            maxLength: 0
+                      - not:
+                          properties:
+                            kind:
+                              pattern: ^(?:(?:Certificate|Configuration|Iam)Policy)$
                     properties:
                       apiVersion:
                         description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -300,6 +313,19 @@ spec:
                         description: Additional PolicyDependencies that only apply to this template
                         items:
                           description: Each PolicyDepenency defines an object reference which must be in a certain compliance state before the policy should be created.
+                          oneOf:
+                            - properties:
+                                kind:
+                                  enum:
+                                    - CertificatePolicy
+                                    - ConfigurationPolicy
+                                    - IamPolicy
+                                namespace:
+                                  maxLength: 0
+                            - not:
+                                properties:
+                                  kind:
+                                    pattern: ^(?:(?:Certificate|Configuration|Iam)Policy)$
                           properties:
                             apiVersion:
                               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'


### PR DESCRIPTION
Note that the apiextensions.k8s.io/v1beta1 CRD is not updated; the way the patch is applied in the propagator repository means that it doesn't apply when generating that version of the CRD. But since the purpose of the validation is to help users on the hub, and the non-updated version is only on (some) managed clusters, it doesn't seem necessary to complicate the process to make that work.

Refs:
 - https://github.com/open-cluster-management-io/governance-policy-propagator/pull/73

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>