### PR TITLE
Update monitoring role for config policy

### DIFF
--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/monitoring_role.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/monitoring_role.yaml
@@ -18,6 +18,9 @@ rules:
     resources:
       - services
       - pods
+      - endpoints
+      - nodes
+      - secrets
     verbs:
       - get
       - list


### PR DESCRIPTION
As mentioned in a comment in the metrics doc, our config policy metrics are not showing up on managed clusters, but it works on the hub I'm guessing because the roles are obtained another way.  I followed this doc to make these updates:
https://docs.openshift.com/container-platform/4.11/operators/operator_sdk/osdk-monitoring-prometheus.html After updating, the prometheus on the managed cluster was able to start collecting the metrics.

Refs:
 - https://issues.redhat.com/browse/ACM-2324

Signed-off-by: Gus Parvin <gparvin@redhat.com>