### PR TITLE
Upgrade failed with missing permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -141,6 +141,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - policy.open-cluster-management.io
   resources:
   - policies


### PR DESCRIPTION
Adding some permissions that were missing.  The missing permissions only seem to be encountered when upgrading from an old version

Refs:
 - https://issues.redhat.com/browse/ACM-2355

Signed-off-by: Gus Parvin <gparvin@redhat.com>