### PR TITLE
ACM-2366: Hosted instances cannot share the ServiceMonitor

### DIFF
--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/service_monitor.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/service_monitor.yaml
@@ -4,7 +4,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: ocm-{{ include "controller.fullname" . }}-metrics
+  name: ocm-{{ include "controller.fullname" . }}-{{ .Release.Namespace }}-metrics
   namespace: {{ .Values.prometheus.serviceMonitor.namespace | default .Release.Namespace }}
   labels:
     app: {{ include "controller.fullname" . }}

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -350,7 +350,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 			By(logPrefix + "verifying that the metrics ServiceMonitor exists")
 			Eventually(func(g Gomega) {
 				sm, err := cluster.clusterClient.Resource(gvrServiceMonitor).Namespace(addonNamespace).Get(
-					context.TODO(), "ocm-config-policy-controller-metrics", metav1.GetOptions{},
+					context.TODO(), "ocm-config-policy-controller-"+addonNamespace+"-metrics", metav1.GetOptions{},
 				)
 				g.Expect(err).To(BeNil())
 
@@ -446,7 +446,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 			By(logPrefix + "verifying that the metrics ServiceMonitor exists")
 			Eventually(func(g Gomega) {
 				sm, err := cluster.clusterClient.Resource(gvrServiceMonitor).Namespace("openshift-monitoring").Get(
-					context.TODO(), "ocm-config-policy-controller-metrics", metav1.GetOptions{},
+					context.TODO(), "ocm-config-policy-controller-"+addonNamespace+"-metrics", metav1.GetOptions{},
 				)
 				g.Expect(err).To(BeNil())
 


### PR DESCRIPTION
The hosted instance of config policy controller are all trying to own the same SErviceMonitor creating a lot of continual updates to that file as each manifestwork tries to apply its differeing contents due to the local managed cluster instance and 2 hosted instances on the hosting cluster.

Refs:
 - https://issues.redhat.com/browse/ACM-2366

Signed-off-by: Gus Parvin <gparvin@redhat.com>