### PR TITLE
Reduce permissions required by service monitor

### DIFF
--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/monitoring_role.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/monitoring_role.yaml
@@ -19,8 +19,6 @@ rules:
       - services
       - pods
       - endpoints
-      - nodes
-      - secrets
     verbs:
       - get
       - list


### PR DESCRIPTION
Reducing the permissions added by pr
https://github.com/open-cluster-management-io/governance-policy-addon-controller/pull/40 We discovered only the endpoints permission was needed.  The secrets and nodes was not needed.  Since those were documented there is a chance there could be some scenario where the extra permissions are needed.  Preferring to keep the rbac more restrictive.

Signed-off-by: Gus Parvin <gparvin@redhat.com>