### PR TITLE
Grant the policy framework kube-rbac-proxy access

### DIFF
--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/kube_rbac_proxy_role.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/kube_rbac_proxy_role.yaml
@@ -1,0 +1,29 @@
+# Copyright Contributors to the Open Cluster Management project
+# Note that this only needs to be created in hosted mode since the controller has all permissions on the managed
+# cluster.
+
+{{- if and (eq .Values.installMode "Hosted") .Values.prometheus.enabled (eq .Values.kubernetesDistribution "OpenShift") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: open-cluster-management:{{ include "controller.fullname" . }}-kube-rbac-proxy
+  labels:
+      app: {{ include "controller.fullname" . }}
+      chart: {{ include "controller.chart" . }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      addon.open-cluster-management.io/hosted-manifest-location: hosting
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+{{- end }}

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/kube_rbac_proxy_role_binding.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/kube_rbac_proxy_role_binding.yaml
@@ -1,0 +1,24 @@
+# Copyright Contributors to the Open Cluster Management project
+# Note that this only needs to be created in hosted mode since the controller has all permissions on the managed
+# cluster.
+
+{{- if and (eq .Values.installMode "Hosted") .Values.prometheus.enabled (eq .Values.kubernetesDistribution "OpenShift") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ocm-{{ .Release.Namespace }}:{{ include "controller.fullname" . }}-kube-rbac-proxy
+  labels:
+      app: {{ include "controller.fullname" . }}
+      chart: {{ include "controller.chart" . }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      addon.open-cluster-management.io/hosted-manifest-location: hosting
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: open-cluster-management:{{ include "controller.fullname" . }}-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: {{ include "controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/kube_rbac_proxy_role.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/kube_rbac_proxy_role.yaml
@@ -1,0 +1,27 @@
+# Copyright Contributors to the Open Cluster Management project
+
+{{- if and .Values.prometheus.enabled (eq .Values.kubernetesDistribution "OpenShift") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: open-cluster-management:{{ include "controller.fullname" . }}-kube-rbac-proxy
+  labels:
+      app: {{ include "controller.fullname" . }}
+      chart: {{ include "controller.chart" . }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      addon.open-cluster-management.io/hosted-manifest-location: hosting
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+{{- end }}

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/kube_rbac_proxy_role_binding.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/kube_rbac_proxy_role_binding.yaml
@@ -1,0 +1,26 @@
+# Copyright Contributors to the Open Cluster Management project
+
+{{- if and .Values.prometheus.enabled (eq .Values.kubernetesDistribution "OpenShift") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  {{- if eq .Values.installMode "Hosted" }}
+  name: ocm-{{ .Release.Namespace }}:{{ include "controller.fullname" . }}-kube-rbac-proxy
+  {{- else }}
+  name: open-cluster-management:{{ include "controller.fullname" . }}-kube-rbac-proxy
+  {{- end }}
+  labels:
+      app: {{ include "controller.fullname" . }}
+      chart: {{ include "controller.chart" . }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      addon.open-cluster-management.io/hosted-manifest-location: hosting
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: open-cluster-management:{{ include "controller.fullname" . }}-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: {{ include "controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
This allows Prometheus to scrape the metrics endpoint.

The second commit fixes the kube-rbac-proxy permissions for the config-policy-controller in hosted mode.

Relates:
https://issues.redhat.com/browse/ACM-2459