### PR TITLE
Set default container for `kubectl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ The `governance-policy-addon-controller` is part of the `open-cluster-management
 
 These instructions assume:
 
-- You have at least one running kubernetes cluster;
+- You have at least one running kubernetes cluster
 - You have already followed instructions from
   [registration-operator](https://github.com/open-cluster-management-io/registration-operator) and
-  installed OCM successfully;
-- At least one managed cluster has been imported and accepted.
+  installed OCM successfully
+- At least one managed cluster has been imported and accepted
 
 ### Deploying the controller
 
@@ -75,7 +75,7 @@ kubectl -n my-managed-cluster annotate managedclusteraddon config-policy-control
 Any values in the
 [Helm chart's values.yaml](./pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml) can
 be modified with the `addon.open-cluster-management.io/values` annotation. However, the structure
-of that annotation makes it difficult to apply mutliple changes - separate `kubectl annotate`
+of that annotation makes it difficult to apply multiple changes - separate `kubectl annotate`
 commands will override each other, as opposed to being merged.
 
 To address this issue, there are some separate annotations that can be applied independently:
@@ -94,12 +94,24 @@ starting a kind cluster, installing the
 [registration-operator](https://github.com/open-cluster-management-io/registration-operator), and
 importing a cluster.
 
-Alternatively, you can run `./build/manage-clusters.sh` to deploy a hub and a configurable number of
-managed clusters (defaults to one) using Kind.
+Alternatively, you can run:
+- `./build/manage-clusters.sh` to deploy a hub and a configurable number of managed clusters 
+  (defaults to one) using Kind
+- `make kind-bootstrap-cluster`, a wrapper for the `./build/manage-clusters.sh` script
+- `make kind-bootstrap-cluster-dev`, a wrapper for the `./build/manage-clusters.sh` script that stops 
+  short of deploying the controller so that the controller can be run locally.
+
+*Note*: You may need to run `make clean` if there are existing stale `kubeconfig` files at the root 
+of the repo.
 
 Before the addons can be successfully distributed to the managed cluster, the work-agent must be
 started. This usually happens automatically within 5 minutes of importing the managed cluster, and
 can be waited for programmatically with the `wait-for-work-agent` make target.
+
+To deploy basic `ManagedClusterAddons` to all managed clusters, you can run `make kind-deploy-addons`.
+
+To delete created clusters, you can use the `make kind-bootstrap-delete-clusters` target, a wrapper 
+for the `./build/manage-clusters.sh` script.
 
 ### Deploying changes
 

--- a/build/manage-clusters.sh
+++ b/build/manage-clusters.sh
@@ -39,6 +39,9 @@ case ${RUN_MODE} in
   create-dev)
     make kind-prep-ocm
     ;;
+  deploy-addons)
+    make kind-deploy-addons-hub
+    ;;
 esac
 
 # Deploy a variable number of managed clusters starting with cluster2
@@ -62,6 +65,11 @@ for i in $(seq 2 $((MANAGED_CLUSTER_COUNT+1))); do
       # Approval takes place on the hub
       export KIND_NAME="${KIND_PREFIX}1"
       make kind-approve-cluster
+      ;;
+    deploy-addons)
+      # ManagedClusterAddon is applied to the hub
+      export KIND_NAME="${KIND_PREFIX}1"
+      make kind-deploy-addons-managed
       ;;
   esac
 done

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -101,6 +101,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -132,16 +140,6 @@ rules:
   - watch
 - apiGroups:
   - ""
-  resourceNames:
-  - policy-encryption-key
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
   resources:
   - pods
   verbs:
@@ -149,9 +147,11 @@ rules:
   - list
   - watch
 - apiGroups:
-  - config.openshift.io
+  - ""
+  resourceNames:
+  - policy-encryption-key
   resources:
-  - infrastructures
+  - secrets
   verbs:
   - get
   - list

--- a/main.go
+++ b/main.go
@@ -71,6 +71,8 @@ import (
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies/status,verbs=get;patch;update
 //+kubebuilder:rbac:groups=core,resources=secrets,resourceNames=policy-encryption-key,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+//+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
 
 var (
 	setupLog    = ctrl.Log.WithName("setup")

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubectl.kubernetes.io/default-container: {{ .Chart.Name }}
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: {{ include "controller.fullname" . }}

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubectl.kubernetes.io/default-container: governance-policy-framework-addon
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: {{ include "controller.fullname" . }}


### PR DESCRIPTION
- This allows `kubectl logs` to correctly determine the default container (i.e. not the proxy container)

Additionally:
- Makefile and associated README updates:
  - Add `kind-bootstrap-cluster` to match other GRC repos.
  - Add `kind-deploy-addons` targets to deploy basic ManagedClusterAddon manifests.
  - Fix missing kubeconfig reference in kubectl command.
- Add `kubebuilder` configuration to match controller role permissions

