### PR TITLE
Use enum for dependency compliance

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
@@ -57,6 +57,10 @@ spec:
                     type: string
                   compliance:
                     description: The ComplianceState (at path .status.compliant) required before the policy should be created
+                    enum:
+                    - NonCompliant
+                    - Compliant
+                    - Pending
                     type: string
                   kind:
                     description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -90,6 +94,10 @@ spec:
                           type: string
                         compliance:
                           description: The ComplianceState (at path .status.compliant) required before the policy should be created
+                          enum:
+                          - NonCompliant
+                          - Compliant
+                          - Pending
                           type: string
                         kind:
                           description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -135,6 +143,7 @@ spec:
               description: ComplianceState shows the state of enforcement
               enum:
                 - Compliant
+                - Pending
                 - NonCompliant
               type: string
             details:
@@ -272,6 +281,10 @@ spec:
                         type: string
                       compliance:
                         description: The ComplianceState (at path .status.compliant) required before the policy should be created
+                        enum:
+                        - NonCompliant
+                        - Compliant
+                        - Pending
                         type: string
                       kind:
                         description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -305,6 +318,10 @@ spec:
                               type: string
                             compliance:
                               description: The ComplianceState (at path .status.compliant) required before the policy should be created
+                              enum:
+                              - NonCompliant
+                              - Compliant
+                              - Pending
                               type: string
                             kind:
                               description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -350,6 +367,7 @@ spec:
                   description: ComplianceState shows the state of enforcement
                   enum:
                     - Compliant
+                    - Pending
                     - NonCompliant
                   type: string
                 details:


### PR DESCRIPTION
Adds an enum for `dependencies[].compliance` and `extraDependencies[].compliance` to block creation of policies with that field set incorrectly. This will fix policies creating with invalid dependencies.

refs:
- https://issues.redhat.com/browse/ACM-2148