### PR TITLE
Grant the hosted mode SA access to manage the the deployment

### DIFF
--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cluster_role.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cluster_role.yaml
@@ -32,6 +32,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  resourceNames:
+  - {{ include "controller.fullname" . }}
+- apiGroups:
   - ""
   resources:
   - pods


### PR DESCRIPTION
It needs access to get and update finalizers on the deployment depending on if pruneObjectBehavior is set.

Relates:
https://issues.redhat.com/browse/ACM-2923