### PR TITLE
Double the framework-addon's default resources

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
@@ -15,9 +15,9 @@ hubKubeConfigSecret: governance-policy-framework-hub-kubeconfig
 
 resources:
   requests:
-    memory: 128Mi
+    memory: 64Mi
   limits:
-    memory: 256Mi
+    memory: 512Mi
 
 affinity: {}
 


### PR DESCRIPTION
When the status-sync controller starts, it looks through all events on the cluster that involves a policy. This may be a huge number of events, and in some instances it has exceeded the memory limit, resulting in Kubernetes killing the process.

Previously, the spec-sync, status-sync, and template-sync controllers were in separate containers, each with their own memory requests and limits. When they were combined into one container, the requests per container were not changed. After this change's increase, the requests and limits are still lower for the pod overall compared to when the controllers were combined.

Refs:
 - https://issues.redhat.com/browse/ACM-3879