### PR TITLE
Add Gatekeeper permissions to framework

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/cluster_role.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/cluster_role.yaml
@@ -1,7 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "controller.rolename" . }}-crd
+  name: {{ include "controller.rolename" . }}
+  
   labels:
     app: {{ include "controller.fullname" . }}
     chart: {{ include "controller.chart" . }}
@@ -15,4 +16,28 @@ rules:
   - customresourcedefinitions
   verbs:
   - list
+  - watch
+- apiGroups:
+  - constraints.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - templates.gatekeeper.sh
+  resources:
+  - constrainttemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/cluster_role_binding.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/cluster_role_binding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "controller.rolename" . }}-crd-binding
+  name: {{ include "controller.rolename" . }}-binding
   labels:
     app: {{ include "controller.fullname" . }}
     chart: {{ include "controller.chart" . }}
@@ -13,7 +13,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "controller.rolename" . }}-crd
+  name: {{ include "controller.rolename" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "controller.serviceAccountName" . }}


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ACM-3327

Resolve this error:
```
	/go/pkg/mod/k8s.io/apimachinery@v0.23.10/pkg/util/wait/wait.go:732023-03-17T21:18:03.922Z	error	klog	cache/reflector.go:138	pkg/mod/k8s.io/client-go@v0.23.10/tools/cache/reflector.go:167: Failed to watch *v1beta1.ConstraintTemplate: failed to list *v1beta1.ConstraintTemplate: constrainttemplates.templates.gatekeeper.sh is forbidden: User "system:serviceaccount:open-cluster-management-agent-addon:governance-policy-framework-sa" cannot list resource "constrainttemplates" in API group "templates.gatekeeper.sh" at the cluster scope

k8s.io/client-go/tools/cache.DefaultWatchErrorHandler
	/go/pkg/mod/k8s.io/client-go@v0.23.10/tools/cache/reflector.go:138
k8s.io/client-go/tools/cache.(*Reflector).Run.func1
	/go/pkg/mod/k8s.io/client-go@v0.23.10/tools/cache/reflector.go:222
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
	/go/pkg/mod/k8s.io/apimachinery@v0.23.10/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
	/go/pkg/mod/k8s.io/apimachinery@v0.23.10/pkg/util/wait/wait.go:156
k8s.io/client-go/tools/cache.(*Reflector).Run
	/go/pkg/mod/k8s.io/client-go@v0.23.10/tools/cache/reflector.go:220
k8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel.func1
	/go/pkg/mod/k8s.io/apimachinery@v0.23.10/pkg/util/wait/wait.go:56
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1
```