### PR TITLE
Fix empty kind version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,12 +166,12 @@ MANAGED_CLUSTER_NAME ?= cluster1
 KIND_VERSION ?= latest
 KUSTOMIZE_VERSION ?= v5.0.0
 # Set the Kind version tag
-ifeq ($(KIND_VERSION), minimum)
-	KIND_ARGS = --image kindest/node:v1.19.16
-else ifneq ($(KIND_VERSION), latest)
-	KIND_ARGS = --image kindest/node:$(KIND_VERSION)
-else
-	KIND_ARGS =
+ifdef KIND_VERSION
+  ifeq ($(KIND_VERSION), minimum)
+    KIND_ARGS = --image kindest/node:v1.19.16
+  else ifneq ($(KIND_VERSION), latest)
+    KIND_ARGS = --image kindest/node:$(KIND_VERSION)
+  endif
 endif
 
 .PHONY: kind-bootstrap-cluster

--- a/build/manage-clusters.sh
+++ b/build/manage-clusters.sh
@@ -7,7 +7,7 @@ else
 fi
 
 # Number of managed clusters
-MANAGED_CLUSTER_COUNT=${MANAGED_CLUSTER_COUNT:-1}
+MANAGED_CLUSTER_COUNT="${MANAGED_CLUSTER_COUNT:-1}"
 if [[ -n "${MANAGED_CLUSTER_COUNT//[0-9]}" ]] || [[ "${MANAGED_CLUSTER_COUNT}" == "0" ]]; then
   echo "error: provided MANAGED_CLUSTER_COUNT is not a nonzero integer"
   exit 1
@@ -15,7 +15,7 @@ fi
 
 HUB_KIND_VERSION=$KIND_VERSION
 if [[ "${KIND_VERSION}" == "minimum" ]]; then
-  # The hub supports less Kubernetes versions than the managed cluster.
+  # The hub supports fewer Kubernetes versions than the managed cluster.
   HUB_KIND_VERSION=v1.23.13
 fi
 
@@ -33,10 +33,10 @@ case ${RUN_MODE} in
     make e2e-debug
     ;;
   create)
-    KIND_VERSION=$HUB_KIND_VERSION make kind-deploy-controller
+    KIND_VERSION="${HUB_KIND_VERSION}" make kind-deploy-controller
     ;;
   create-dev)
-    KIND_VERSION=$HUB_KIND_VERSION make kind-prep-ocm
+    KIND_VERSION="${HUB_KIND_VERSION}" make kind-prep-ocm
     ;;
   deploy-addons)
     make kind-deploy-addons-hub


### PR DESCRIPTION
`KIND_HUB_VERSION` was being set to an empty string when the script was run without `KIND_VERSION`, so it was resulting in `--image kindest/node:` with no tag specified.