### PR TITLE
3329 framework addon cleanup

### DIFF
--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cleanup_pod.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cleanup_pod.yaml
@@ -43,12 +43,12 @@ spec:
         {{- end }}
       resources: {{- toYaml .Values.resources | nindent 10 }}
       securityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-        - ALL
-      privileged: false
-      readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        privileged: false
+        readOnlyRootFilesystem: true
   {{- if .Values.global.imagePullSecret }}
   imagePullSecrets:
   - name: "{{ .Values.global.imagePullSecret }}"

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/cleanup_pod.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/cleanup_pod.yaml
@@ -1,0 +1,67 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "controller.fullname" . }}-uninstall
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "controller.fullname" . }}
+    chart: {{ include "controller.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+  annotations:
+    addon.open-cluster-management.io/addon-pre-delete: ""
+spec:
+  restartPolicy: OnFailure
+  containers:
+    - name: {{ .Chart.Name }}-uninstall
+      image: "{{ .Values.global.imageOverrides.governance_policy_framework_addon }}"
+      imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
+      command: ["governance-policy-framework-addon"]
+      args:
+        - trigger-uninstall
+        - --deployment-name={{ include "controller.fullname" . }}
+        - --deployment-namespace={{ .Release.Namespace }}
+        {{- if eq .Values.installMode "Hosted" }}
+        - --policy-namespace={{ .Release.Namespace }}
+        {{- else }}
+        - --policy-namespace={{ .Values.clusterName }}
+        {{- end }}
+      env:
+        - name: OPERATOR_NAME
+          value: "governance-policy-framework-addon"
+        {{- if .Values.global.proxyConfig }}
+        - name: HTTP_PROXY
+          value: {{ .Values.global.proxyConfig.HTTP_PROXY }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.global.proxyConfig.HTTPS_PROXY }}
+        - name: NO_PROXY
+          value: {{ .Values.global.proxyConfig.NO_PROXY }}
+        {{- end }}
+      resources: {{- toYaml .Values.resources | nindent 10 }}
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        privileged: false
+        readOnlyRootFilesystem: true
+  {{- if .Values.global.imagePullSecret }}
+  imagePullSecrets:
+  - name: "{{ .Values.global.imagePullSecret }}"
+  {{- end }}
+  affinity: {{ toYaml .Values.affinity | nindent 8 }}
+  {{- if hasKey .Values "tolerations" }}
+  tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
+  {{- end }}
+  {{- if hasKey .Values.global "nodeSelector" }}
+  nodeSelector: {{ toYaml .Values.global.nodeSelector | nindent 8 }}
+  {{- end }}
+  hostNetwork: false
+  hostPID: false
+  hostIPC: false
+  serviceAccount: {{ include "controller.serviceAccountName" . }}
+  securityContext:
+    runAsNonRoot: true

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/cluster_role.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/cluster_role.yaml
@@ -51,3 +51,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps
+  resourceNames:
+  - {{ include "controller.fullname" . }}
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
@@ -87,6 +87,10 @@ spec:
                 fieldPath: metadata.name
           - name: OPERATOR_NAME
             value: "governance-policy-framework-addon"
+          - name: DEPLOYMENT_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['app']
           {{- if .Values.global.proxyConfig }}
           - name: HTTP_PROXY
             value: {{ .Values.global.proxyConfig.HTTP_PROXY }}

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -409,6 +409,17 @@ var _ = Describe("Test framework deployment", func() {
 				return len(manifests)
 			}, 30, 5).Should(Equal(defaultLength + 1))
 
+			By(logPrefix + "removing the pause annotation")
+			Kubectl("annotate", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, "policy-addon-pause-")
+
+			By(logPrefix + "verifying the edit is reverted after the annotation was removed")
+			Eventually(func() int {
+				mw := GetWithTimeout(clientDynamic, gvrManifestWork, case1MWName, cluster.clusterName, true, 15)
+				manifests, _, _ := unstructured.NestedSlice(mw.Object, "spec", "workload", "manifests")
+
+				return len(manifests)
+			}, 30, 5).Should(Equal(defaultLength))
+
 			By(logPrefix + "deleting the managedclusteraddon")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, "--timeout=30s")
 			deploy = GetWithTimeout(

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -50,7 +51,7 @@ var _ = Describe("Test framework deployment", func() {
 			checkArgs(cluster, expectedArgs...)
 
 			By(logPrefix + "removing the framework deployment when the ManagedClusterAddOn CR is removed")
-			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, "--timeout=30s")
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
 			)
@@ -86,9 +87,12 @@ var _ = Describe("Test framework deployment", func() {
 				"--cluster-namespace-on-hub="+cluster.clusterName,
 			)
 
+			ctx, cancel := context.WithTimeout(context.TODO(), 15*time.Second)
+			defer cancel()
+
 			By(logPrefix + "removing the framework deployment when the ManagedClusterAddOn CR is removed")
 			err := hubClient.Resource(gvrManagedClusterAddOn).Namespace(cluster.clusterName).Delete(
-				context.TODO(), case1ManagedClusterAddOnName, metav1.DeleteOptions{},
+				ctx, case1ManagedClusterAddOnName, metav1.DeleteOptions{},
 			)
 			Expect(err).To(BeNil())
 
@@ -128,9 +132,12 @@ var _ = Describe("Test framework deployment", func() {
 
 				checkContainersAndAvailabilityInNamespace(cluster, i+1, installNamespace)
 
+				ctx, cancel := context.WithTimeout(context.TODO(), 15*time.Second)
+				defer cancel()
+
 				By(logPrefix + "verifying removing the framework deployment when the ManagedClusterAddOn CR is removed")
 				err := hubClient.Resource(gvrManagedClusterAddOn).Namespace(cluster.clusterName).Delete(
-					context.TODO(), case1ManagedClusterAddOnName, metav1.DeleteOptions{},
+					ctx, case1ManagedClusterAddOnName, metav1.DeleteOptions{},
 				)
 				Expect(err).To(BeNil())
 
@@ -141,9 +148,12 @@ var _ = Describe("Test framework deployment", func() {
 				namespace := GetWithTimeout(hubClient, gvrNamespace, installNamespace, "", true, 30)
 				Expect(namespace).NotTo(BeNil())
 
+				ctxNS, cancelNS := context.WithTimeout(context.TODO(), 15*time.Second)
+				defer cancelNS()
+
 				By(logPrefix + "Cleaning up the install namespace")
 				err = hubClient.Resource(gvrNamespace).Delete(
-					context.TODO(), installNamespace, metav1.DeleteOptions{},
+					ctxNS, installNamespace, metav1.DeleteOptions{},
 				)
 				Expect(err).To(BeNil())
 
@@ -151,9 +161,9 @@ var _ = Describe("Test framework deployment", func() {
 				Expect(namespace).To(BeNil())
 			}
 			By("Deleting the AddOnDeploymentConfig")
-			Kubectl("delete", "-f", addOnDeplomentConfigWithCustomVarsCR)
+			Kubectl("delete", "-f", addOnDeplomentConfigWithCustomVarsCR, "--timeout=15s")
 			By("Deleting the config-policy-controller ClusterManagementAddOn to use the AddOnDeploymentConfig")
-			Kubectl("delete", "-f", case1ClusterManagementAddOnCR)
+			Kubectl("delete", "-f", case1ClusterManagementAddOnCR, "--timeout=15s")
 		})
 
 	It("should create a framework deployment with custom logging levels", func() {
@@ -179,7 +189,7 @@ var _ = Describe("Test framework deployment", func() {
 			checkArgs(cluster, "--log-encoder=console", "--log-level=8", "--v=6")
 
 			By(logPrefix + "removing the framework deployment when the ManagedClusterAddOn CR is removed")
-			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, "--timeout=30s")
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
 			)
@@ -232,7 +242,7 @@ var _ = Describe("Test framework deployment", func() {
 			Expect(tolerations[0]).To(Equal(expected))
 
 			By(logPrefix + "removing the framework deployment when the ManagedClusterAddOn CR is removed")
-			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, "--timeout=30s")
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
 			)
@@ -240,9 +250,9 @@ var _ = Describe("Test framework deployment", func() {
 		}
 
 		By("Deleting the AddOnDeploymentConfig")
-		Kubectl("delete", "-f", addOnDeplomentConfigCR)
+		Kubectl("delete", "-f", addOnDeplomentConfigCR, "--timeout=15s")
 		By("Deleting the governance-policy-framework ClusterManagementAddOn to use the AddOnDeploymentConfig")
-		Kubectl("delete", "-f", case1ClusterManagementAddOnCR)
+		Kubectl("delete", "-f", case1ClusterManagementAddOnCR, "--timeout=15s")
 	})
 
 	It("should use the onManagedClusterHub value set in helm values annotation", func() {
@@ -268,7 +278,7 @@ var _ = Describe("Test framework deployment", func() {
 		checkArgs(cluster, "--log-encoder=console", "--log-level=8", "--v=6")
 
 		By(logPrefix + "deleting the managedclusteraddon")
-		Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+		Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, "--timeout=30s")
 		deploy = GetWithTimeout(
 			cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
 		)
@@ -303,7 +313,7 @@ var _ = Describe("Test framework deployment", func() {
 		checkArgs(cluster, "--log-encoder=console", "--log-level=8", "--v=6")
 
 		By(logPrefix + "deleting the managedclusteraddon")
-		Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+		Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, "--timeout=30s")
 		deploy = GetWithTimeout(
 			cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
 		)
@@ -352,7 +362,7 @@ var _ = Describe("Test framework deployment", func() {
 			}, 60, 5).Should(Equal(defaultLength))
 
 			By(logPrefix + "deleting the managedclusteraddon")
-			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, "--timeout=30s")
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
 			)
@@ -400,7 +410,7 @@ var _ = Describe("Test framework deployment", func() {
 			}, 30, 5).Should(Equal(defaultLength + 1))
 
 			By(logPrefix + "deleting the managedclusteraddon")
-			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, "--timeout=30s")
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
 			)
@@ -427,7 +437,7 @@ var _ = Describe("Test framework deployment", func() {
 			GetWithTimeoutClusterResource(cluster.clusterClient, gvrNamespace, cluster.clusterName, true, 15)
 
 			By(logPrefix + "deleting the managedclusteraddon")
-			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, "--timeout=30s")
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
 			)
@@ -471,7 +481,7 @@ var _ = Describe("Test framework deployment", func() {
 			}
 
 			By(logPrefix + "deleting the managedclusteraddon")
-			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, "--timeout=30s")
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
 			)


### PR DESCRIPTION
Adds the pre-delete hook to cleanly uninstall the framework addon. Without this, resources with finalizers can get left behind.

https://issues.redhat.com/browse/ACM-3329