### PR TITLE
Add client QPS and Burst customization to cfg-pol

### DIFF
--- a/pkg/addon/common.go
+++ b/pkg/addon/common.go
@@ -39,9 +39,9 @@ type GlobalValues struct {
 }
 
 type UserArgs struct {
-	LogEncoder  string `json:"logEncoder,"`
-	LogLevel    int8   `json:"logLevel,"`
-	PkgLogLevel int8   `json:"pkgLogLevel,"`
+	LogEncoder  string `json:"logEncoder,omitempty"`
+	LogLevel    int8   `json:"logLevel,omitempty"`
+	PkgLogLevel int8   `json:"pkgLogLevel,omitempty"`
 }
 
 type UserValues struct {

--- a/pkg/addon/configpolicy/agent_addon.go
+++ b/pkg/addon/configpolicy/agent_addon.go
@@ -21,6 +21,8 @@ import (
 const (
 	addonName                       = "config-policy-controller"
 	evaluationConcurrencyAnnotation = "policy-evaluation-concurrency"
+	clientQPSAnnotation             = "client-qps"
+	clientBurstAnnotation           = "client-burst"
 	prometheusEnabledAnnotation     = "prometheus-metrics-enabled"
 )
 
@@ -28,7 +30,9 @@ var log = ctrl.Log.WithName("configpolicy")
 
 type UserArgs struct {
 	policyaddon.UserArgs
-	EvaluationConcurrency uint8 `json:"evaluationConcurrency,"`
+	EvaluationConcurrency uint8 `json:"evaluationConcurrency,omitempty"`
+	ClientQPS             uint8 `json:"clientQPS,omitempty"` //nolint:tagliatelle
+	ClientBurst           uint8 `json:"clientBurst,omitempty"`
 }
 
 type UserValues struct {
@@ -76,7 +80,10 @@ func getValues(cluster *clusterv1.ManagedCluster,
 				LogLevel:    0,
 				PkgLogLevel: -1,
 			},
-			EvaluationConcurrency: 2,
+			// Defaults from `values.yaml` will be used if these stay at 0.
+			EvaluationConcurrency: 0,
+			ClientQPS:             0, // will be set based on concurrency if not explicitly set
+			ClientBurst:           0, // will be set based on concurrency if not explicitly set
 		},
 	}
 
@@ -115,7 +122,38 @@ func getValues(cluster *clusterv1.ManagedCluster,
 		}
 	}
 
-	if val, ok := addon.GetAnnotations()[prometheusEnabledAnnotation]; ok {
+	if val, ok := annotations[clientQPSAnnotation]; ok {
+		value, err := strconv.ParseUint(val, 10, 8)
+		if err != nil {
+			log.Error(err, fmt.Sprintf(
+				"Failed to verify '%s' annotation value '%s' for component %s (falling back to default value %d)",
+				clientQPSAnnotation, val, addonName, userValues.UserArgs.ClientQPS),
+			)
+		} else {
+			// This is safe because we specified the uint8 in ParseUint
+			userValues.UserArgs.ClientQPS = uint8(value)
+		}
+	} else { // not set explicitly
+		userValues.UserArgs.ClientQPS = userValues.UserArgs.EvaluationConcurrency * 15
+	}
+
+	if val, ok := annotations[clientBurstAnnotation]; ok {
+		value, err := strconv.ParseUint(val, 10, 8)
+		if err != nil {
+			log.Error(err, fmt.Sprintf(
+				"Failed to verify '%s' annotation value '%s' for component %s (falling back to default value %d)",
+				clientBurstAnnotation, val, addonName, userValues.UserArgs.ClientBurst),
+			)
+		} else {
+			// This is safe because we specified the uint8 in ParseUint
+			userValues.UserArgs.ClientBurst = uint8(value)
+		}
+	} else if userValues.UserArgs.EvaluationConcurrency != 0 {
+		// only scale with concurrency if concurrency was set.
+		userValues.UserArgs.ClientBurst = userValues.UserArgs.EvaluationConcurrency*22 + 1
+	}
+
+	if val, ok := annotations[prometheusEnabledAnnotation]; ok {
 		valBool, err := strconv.ParseBool(val)
 		if err != nil {
 			log.Error(err, fmt.Sprintf(

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cleanup_pod.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cleanup_pod.yaml
@@ -29,8 +29,6 @@ spec:
         {{- else }}
         - --policy-namespace={{ .Values.clusterName }}
         {{- end }}
-        - --log-encoder={{ .Values.args.logEncoder }}
-        - --log-level={{ .Values.args.logLevel }}
         - --v={{ .Values.args.pkgLogLevel }}
       env:
         {{- if .Values.global.proxyConfig }}

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -70,6 +70,8 @@ spec:
           - --log-level={{ .Values.args.logLevel }}
           - --v={{ .Values.args.pkgLogLevel }}
           - --evaluation-concurrency={{ .Values.args.evaluationConcurrency }}
+          - --client-max-qps={{ .Values.args.clientQPS }}
+          - --client-burst={{ .Values.args.clientBurst }}
           - --health-probe-bind-address=:8081
           {{- if and .Values.prometheus.enabled (ne .Values.kubernetesDistribution "OpenShift") }}
           - --metrics-bind-address=0.0.0.0:8383

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
@@ -10,6 +10,8 @@ args:
   pkgLogLevel: -1
   logEncoder: console
   evaluationConcurrency: 2
+  clientQPS: 30
+  clientBurst: 45
 hubKubeConfigSecret: config-policy-controller-hub-kubeconfig
 
 resources:

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -313,10 +313,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 				evaluationConcurrencyAnnotation,
 			)
 
-			By(
-				logPrefix + "annotating the managedclusteraddon with the " + prometheusEnabledAnnotation +
-					" annotation",
-			)
+			By(logPrefix + "annotating the managedclusteraddon with the " + prometheusEnabledAnnotation + " annotation")
 			Kubectl(
 				"annotate",
 				"-n",
@@ -325,6 +322,9 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 				case2ManagedClusterAddOnCR,
 				prometheusEnabledAnnotation,
 			)
+
+			By(logPrefix + "annotating the managedclusteraddon with the " + clientQPSAnnotation + " annotation")
+			Kubectl("annotate", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR, clientQPSAnnotation)
 
 			By(logPrefix + "verifying the pod has been deployed with a new logging level and concurrency")
 			Eventually(func(g Gomega) {
@@ -350,6 +350,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 						g.Expect(args).To(ContainElement("--log-level=8"))
 						g.Expect(args).To(ContainElement("--v=6"))
 						g.Expect(args).To(ContainElement("--evaluation-concurrency=5"))
+						g.Expect(args).To(ContainElement("--client-max-qps=50"))
 						g.Expect(args).To(ContainElement("--leader-elect=false"))
 					}
 				}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -25,6 +25,7 @@ const (
 	kubeconfigFilename                   string = "../../policy-addon-ctrl"
 	loggingLevelAnnotation               string = "log-level=8"
 	evaluationConcurrencyAnnotation      string = "policy-evaluation-concurrency=5"
+	clientQPSAnnotation                  string = "client-qps=50"
 	prometheusEnabledAnnotation          string = "prometheus-metrics-enabled=true"
 	addOnDeplomentConfigCR               string = "../resources/addondeploymentconfig.yaml"
 	addOnDeplomentConfigWithCustomVarsCR string = "../resources/addondeploymentconfig_customvars.yaml"


### PR DESCRIPTION
This allows the new `--client-max-qps` and `--client-burst` arguments on the configuration-policy-controller to be modified by the user. If those are not explicitly configured, their values will scale with the configured evaluation concurrency.

As part of this change, more values will be omitted when empty, which allows for the default values from the `values.yaml` to be used, and allows for other layers of configuration (eg AddOnDeploymentConfig) to be effective, as opposed to the default in `getValues` always being used.

Refs:
 - https://issues.redhat.com/browse/ACM-4297