### PR TITLE
Stop incorrectly managing the Policy CRD on the hub cluster

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
@@ -1,5 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
+{{- if not .Values.onMulticlusterHub }}
 {{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}
 
 ---
@@ -483,4 +484,5 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}
 {{- end }}

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Test framework deployment", func() {
 				)
 				Expect(err).To(BeNil())
 
-				namespace = GetWithTimeout(hubClient, gvrNamespace, installNamespace, "", false, 30)
+				namespace = GetWithTimeout(hubClient, gvrNamespace, installNamespace, "", false, 60)
 				Expect(namespace).To(BeNil())
 			}
 			By("Deleting the AddOnDeploymentConfig")

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -269,7 +269,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 				)
 				Expect(err).To(BeNil())
 
-				namespace = GetWithTimeout(hubClient, gvrNamespace, installNamespace, "", false, 30)
+				namespace = GetWithTimeout(hubClient, gvrNamespace, installNamespace, "", false, 60)
 				Expect(namespace).To(BeNil())
 			}
 			By("Deleting the AddOnDeploymentConfig")


### PR DESCRIPTION
The Policy CRD on the hub cluster should be managed by the installer. This will prevent possible conflicts due to version drift, and allow the hub side of the policy framework to continue functioning if a self-managed hub stops managing itself.

Refs:
 - https://issues.redhat.com/browse/ACM-4917
