### PR TITLE
Set seccomp profile for cfg-policy

### DIFF
--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -131,7 +131,6 @@ spec:
           containerPort: 8383
         {{- end }}
         resources: {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
@@ -177,4 +176,6 @@ spec:
       serviceAccount: {{ include "controller.serviceAccountName" . }}
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 120


### PR DESCRIPTION
Only required on config-policy-controller because of the wide range of permissions that it has.

Refs:
 - https://issues.redhat.com/browse/ACM-4590