### PR TITLE
4917 policy crd management attempt 2

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
@@ -1,6 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
 
-{{- if not .Values.onMulticlusterHub }}
 {{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}
 
 ---
@@ -484,5 +483,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}
 {{- end }}

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
@@ -8,6 +8,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.1
+    {{- if .Values.onMulticlusterHub }}
+    "addon.open-cluster-management.io/deletion-orphan": ""
+    {{- end }}
   creationTimestamp: null
   name: policies.policy.open-cluster-management.io
   labels:
@@ -237,6 +240,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.1
+    {{- if .Values.onMulticlusterHub }}
+    "addon.open-cluster-management.io/deletion-orphan": ""
+    {{- end }}
   creationTimestamp: null
   name: policies.policy.open-cluster-management.io
   labels:


### PR DESCRIPTION
The previous attempt to address this issue actually caused the issue in upgrade situations. The new approach ensures that the CRD will not be deleted on the hub when the addon is removed.

There is still a potential conflict because this CRD will be defined on the hub by this controller, and another installer. In a future release, after this "deletion-orphan" annotation has been added, it might be possible to stop defining the CRD on the hub through this controller.

Refs:
 - https://issues.redhat.com/browse/ACM-4917

