### PR TITLE
Enhance crd-sync to add labels and annotations

### DIFF
--- a/build/crd-sync.sh
+++ b/build/crd-sync.sh
@@ -29,15 +29,21 @@ done
     cp deploy/crds/policy.open-cluster-management.io_policies.yaml ../policy-crd-v1beta1.yaml
 )
 
-addLabelsExpression='.metadata.labels += {"addon.open-cluster-management.io/hosted-manifest-location": "hosting"}'
+addLocationLabel='.metadata.labels += {"addon.open-cluster-management.io/hosted-manifest-location": "hosting"}'
+addTemplateLabel='.metadata.labels += {"policy.open-cluster-management.io/policy-type": "template"}'
+
+# This annotation must *only* be added on the hub cluster. On others, we want the CRD removed. 
+# This kind of condition is not valid YAML on its own, so it has to be hacked in.
+addTempAnnotation='.metadata.annotations += {"SEDTARGET": "SEDTARGET"}'
+replaceAnnotation='s/SEDTARGET: SEDTARGET/{{ if .Values.onMulticlusterHub }}"addon.open-cluster-management.io\/deletion-orphan": ""{{ end }}/g'
 
 cat > pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_configurationpolicies_crd.yaml << EOF
 # Copyright Contributors to the Open Cluster Management project
 
 {{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}
-$(yq e "$addLabelsExpression" .go/config-policy-crd-v1beta1.yaml)
+$(yq e "$addLocationLabel | $addTemplateLabel" .go/config-policy-crd-v1beta1.yaml)
 {{ else }}
-$(yq e "$addLabelsExpression" .go/config-policy-crd-v1.yaml)
+$(yq e "$addLocationLabel" .go/config-policy-crd-v1.yaml)
 {{- end }}
 EOF
 
@@ -45,9 +51,9 @@ cat > pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.o
 # Copyright Contributors to the Open Cluster Management project
 
 {{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}
-$(yq e "$addLabelsExpression" .go/policy-crd-v1beta1.yaml)
+$(yq e "$addTempAnnotation | $addLocationLabel" .go/policy-crd-v1beta1.yaml | sed -E "$replaceAnnotation")
 {{ else }}
-$(yq e "$addLabelsExpression" .go/policy-crd-v1.yaml)
+$(yq e "$addTempAnnotation | $addLocationLabel" .go/policy-crd-v1.yaml | sed -E "$replaceAnnotation")
 {{- end }}
 EOF
 

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_configurationpolicies_crd.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_configurationpolicies_crd.yaml
@@ -12,6 +12,7 @@ metadata:
   name: configurationpolicies.policy.open-cluster-management.io
   labels:
     addon.open-cluster-management.io/hosted-manifest-location: hosting
+    policy.open-cluster-management.io/policy-type: template
 spec:
   additionalPrinterColumns:
     - JSONPath: .status.compliant

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
@@ -8,9 +8,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.1
-    {{- if .Values.onMulticlusterHub }}
-    "addon.open-cluster-management.io/deletion-orphan": ""
-    {{- end }}
+    {{ if .Values.onMulticlusterHub }}"addon.open-cluster-management.io/deletion-orphan": ""{{ end }}
   creationTimestamp: null
   name: policies.policy.open-cluster-management.io
   labels:
@@ -240,9 +238,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.1
-    {{- if .Values.onMulticlusterHub }}
-    "addon.open-cluster-management.io/deletion-orphan": ""
-    {{- end }}
+    {{ if .Values.onMulticlusterHub }}"addon.open-cluster-management.io/deletion-orphan": ""{{ end }}
   creationTimestamp: null
   name: policies.policy.open-cluster-management.io
   labels:


### PR DESCRIPTION
The previous update to the Policy CRD which added the "deletion-orphan" annotation would not be persisted through the "crd-sync.sh" script. Now, that script adds the annotation.

The script also adds the "policy-type" annotation to the v1beta1 CRD for ConfigurationPolicy, since that was missing. It is easier to add it here rather than update the kustomization in the other repo, since it never creates the v1beta1 crd in that repo's scripts.

Refs:
 - https://issues.redhat.com/browse/ACM-5326