### PR TITLE
Rename the framework's ClusterRoleBinding

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/cluster_role_binding.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/cluster_role_binding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ocm:{{ .Release.Namespace }}:{{ include "controller.fullname" . }}
+  name: ocm:{{ .Release.Namespace }}:{{ include "controller.fullname" . }}-0
   labels:
     app: {{ include "controller.fullname" . }}
     chart: {{ include "controller.chart" . }}


### PR DESCRIPTION
This ClusterRoleBinding previously pointed to a (now nonexistent) *-crd ClusterRole. Kubernetes will not accept edits to the roleRef in a ClusterRoleBinding, so during an upgrade, the ManifestWork would fail to be applied correctly, and the framework addon could not function.

Renaming this will make the old binding be deleted, and the new binding will be applied properly with the new configuration.

Refs:
 - https://issues.redhat.com/browse/ACM-5383