### PR TITLE
Sec context updates

### DIFF
--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cleanup_pod.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cleanup_pod.yaml
@@ -64,3 +64,9 @@ spec:
   serviceAccount: {{ include "controller.serviceAccountName" . }}
   securityContext:
     runAsNonRoot: true
+    {{- if semverCompare ">= 1.25.0" .Capabilities.KubeVersion.Version }}
+    {{- /* newer OpenShift (4.12+) versions might require this to be explicitly set */}}
+    {{- /* but not all older kubernetes versions can handle when it is set */}}
+    seccompProfile:
+      type: RuntimeDefault
+    {{- end }}

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -51,6 +51,13 @@ spec:
         - mountPath: "/var/run/metrics-cert"
           name: metrics-cert
           readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
       {{- end }}
       - name: {{ .Chart.Name }}
         image: "{{ .Values.global.imageOverrides.config_policy_controller }}"
@@ -131,12 +138,6 @@ spec:
           containerPort: 8383
         {{- end }}
         resources: {{- toYaml .Values.resources | nindent 10 }}
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-          - ALL
-        privileged: false
-        readOnlyRootFilesystem: true
         volumeMounts:
           - name: klusterlet-config
             mountPath: /var/run/klusterlet
@@ -145,6 +146,13 @@ spec:
             name: managed-kubeconfig-secret
             readOnly: true
           {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
       volumes:
         - name: klusterlet-config
           secret:

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -184,6 +184,10 @@ spec:
       serviceAccount: {{ include "controller.serviceAccountName" . }}
       securityContext:
         runAsNonRoot: true
+        {{- if semverCompare ">= 1.25.0" .Capabilities.KubeVersion.Version }}
+        {{- /* newer OpenShift (4.12+) versions might require this to be explicitly set */}}
+        {{- /* but not all older kubernetes versions can handle when it is set */}}
         seccompProfile:
           type: RuntimeDefault
+        {{- end }}
       terminationGracePeriodSeconds: 120

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
@@ -51,6 +51,13 @@ spec:
         - mountPath: "/var/run/metrics-cert"
           name: metrics-cert
           readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
       {{- end }}
       - name: governance-policy-framework-addon
         image: "{{ .Values.global.imageOverrides.governance_policy_framework_addon }}"


### PR DESCRIPTION
Tested against managed clusters using ocp 4.10 and 4.13. Oddly, although the [operator-sdk docs](https://master.sdk.operatorframework.io/docs/best-practices/pod-security-standards/) say that setting the `seccompProfile` might fail on 4.10, it didn't seem to in my test... but it seems reasonable that there is some kubernetes version where it would cause a problem, so I think the conditional templating is still worth it.

Refs:
 - https://issues.redhat.com/browse/ACM-4590
 - https://issues.redhat.com/browse/ACM-5352