### PR TITLE
Add `deletecollection` permissions for policies

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/role.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/role.yaml
@@ -57,3 +57,10 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  # uninstall does a bulk deletion of policies from the cluster namespace
+  - policies
+  verbs:
+  - deletecollection


### PR DESCRIPTION
Uninstall does a bulk deletion of policies

ref: https://issues.redhat.com/browse/ACM-5632