### PR TITLE
Disable framework pre-delete hook on self-managed hub

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/cleanup_pod.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/cleanup_pod.yaml
@@ -1,5 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
+{{- if (not .Values.onMulticlusterHub) }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -65,3 +66,4 @@ spec:
   serviceAccount: {{ include "controller.serviceAccountName" . }}
   securityContext:
     runAsNonRoot: true
+{{- end }}

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 			)
 			Expect(deploy).To(BeNil())
 
-			namespace := GetWithTimeout(hubClient, gvrNamespace, installNamespace, "", false, 30)
+			namespace := GetWithTimeout(hubClient, gvrNamespace, installNamespace, "", false, 60)
 			Expect(namespace).To(BeNil())
 		}
 	})


### PR DESCRIPTION
doc: https://github.com/open-cluster-management-io/addon-framework/blob/main/docs/preDeleteHook.md?plain=1

ref: https://issues.redhat.com/browse/ACM-5632