### PR TITLE
Use the ocm repo instead of the registration-operator

### DIFF
--- a/build/manage-clusters.sh
+++ b/build/manage-clusters.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
 
+set -e
+set -o pipefail
+
 if [[ "${HOSTED_MODE}" == "true" ]]; then
   RUN_MODE=${RUN_MODE:-"create"}
 else


### PR DESCRIPTION
The registration-operator repo was consolidated into the ocm repo, so the Makefile targets used for our CI no longer worked.