### PR TITLE
Use ManagedCluster metadata for k8s distro type

### DIFF
--- a/pkg/addon/configpolicy/agent_addon.go
+++ b/pkg/addon/configpolicy/agent_addon.go
@@ -88,6 +88,11 @@ func getValues(cluster *clusterv1.ManagedCluster,
 		},
 	}
 
+	// Don't just set it to the value in the label, it might be something like "auto-detect"
+	if cluster.Labels["vendor"] == "OpenShift" {
+		userValues.KubernetesDistribution = "OpenShift"
+	}
+
 	for _, cc := range cluster.Status.ClusterClaims {
 		if cc.Name == "product.open-cluster-management.io" {
 			userValues.KubernetesDistribution = cc.Value

--- a/pkg/addon/policyframework/agent_addon.go
+++ b/pkg/addon/policyframework/agent_addon.go
@@ -79,6 +79,11 @@ func getValues(cluster *clusterv1.ManagedCluster,
 		userValues.OnMulticlusterHub = true
 	}
 
+	// Don't just set it to the value in the label, it might be something like "auto-detect"
+	if cluster.Labels["vendor"] == "OpenShift" {
+		userValues.KubernetesDistribution = "OpenShift"
+	}
+
 	for _, cc := range cluster.Status.ClusterClaims {
 		if cc.Name == "product.open-cluster-management.io" {
 			userValues.KubernetesDistribution = cc.Value


### PR DESCRIPTION
The ClusterClaims are not always created before the policy addons are deployed, so in many cases the addons will be quickly re-configured. That slows down the initial reconciliation of policies on new clusters.

This change uses metadata that may be on the ManagedCluster, to try and get the initial configuration correct. The ClusterClaim is still the final source of truth.

Refs:
 - https://issues.redhat.com/browse/ACM-6637