### PR TITLE
Set the uninstallation annotation in the chart

### DIFF
--- a/pkg/addon/configpolicy/agent_addon.go
+++ b/pkg/addon/configpolicy/agent_addon.go
@@ -178,13 +178,17 @@ func getValues(cluster *clusterv1.ManagedCluster,
 // be taken when adding settings to this function.
 func mandateValues(
 	cluster *clusterv1.ManagedCluster,
-	_ *addonapiv1alpha1.ManagedClusterAddOn,
+	mcao *addonapiv1alpha1.ManagedClusterAddOn,
 ) (addonfactory.Values, error) {
 	values := addonfactory.Values{}
 
 	// Don't allow replica overrides for older Kubernetes
 	if policyaddon.IsOldKubernetes(cluster) {
 		values["replicas"] = 1
+	}
+
+	if !mcao.DeletionTimestamp.IsZero() {
+		values["uninstallationAnnotation"] = "true"
 	}
 
 	return values, nil

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -3,6 +3,8 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
+  annotations:
+    policy.open-cluster-management.io/uninstalling: '{{ .Values.uninstallationAnnotation }}'
   name: {{ include "controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
@@ -33,6 +33,7 @@ tolerations:
 
 clusterName: null
 managedKubeConfigSecret: null
+uninstallationAnnotation: "false"
 
 # This is the Kubernetes distribution of the managed cluster. If set to OpenShift,
 # some features such as automatic TLS certificate generation will be used.

--- a/pkg/addon/policyframework/agent_addon.go
+++ b/pkg/addon/policyframework/agent_addon.go
@@ -135,13 +135,17 @@ func getValues(cluster *clusterv1.ManagedCluster,
 // be taken when adding settings to this function.
 func mandateValues(
 	cluster *clusterv1.ManagedCluster,
-	_ *addonapiv1alpha1.ManagedClusterAddOn,
+	mcao *addonapiv1alpha1.ManagedClusterAddOn,
 ) (addonfactory.Values, error) {
 	values := addonfactory.Values{}
 
 	// Don't allow replica overrides for older Kubernetes
 	if policyaddon.IsOldKubernetes(cluster) {
 		values["replicas"] = 1
+	}
+
+	if !mcao.DeletionTimestamp.IsZero() {
+		values["uninstallationAnnotation"] = "true"
 	}
 
 	return values, nil

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
@@ -3,6 +3,8 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
+  annotations:
+    policy.open-cluster-management.io/uninstalling: '{{ .Values.uninstallationAnnotation }}'
   name: {{ include "controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:

--- a/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
@@ -32,6 +32,7 @@ tolerations:
 
 clusterName: null
 installMode: null
+uninstallationAnnotation: "false"
 
 # This is the Kubernetes distribution of the managed cluster. If set to OpenShift,
 # some features such as automatic TLS certificate generation will be used.


### PR DESCRIPTION
In certain situations, if the uninstall procedure was interrupted with a reinstallation, the uninstallation annotations could still be on the managed cluster, in the wrong state. Now, the manifest work should also help manage that annotation, ensuring it will be set to "false" when the policy addons are not supposed to be being uninstalled.

Refs:
 - https://issues.redhat.com/browse/ACM-6941