### PR TITLE
Add support for explicitly enabling the spec sync controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,12 +189,8 @@ kind-bootstrap-delete-clusters: ## Delete clusters created from a bootstrap targ
 kind-bootstrap-deploy-addons: ## Deploy addons to bootstrap clusters.
 	RUN_MODE="deploy-addons" ./build/manage-clusters.sh
 
-.PHONY: kind-deploy-addons-hub
-kind-deploy-addons-hub: kind-deploy-addons-managed ## Apply ManagedClusterAddon manifests to hub to deploy governance addons to a managed hub cluster.
-	KUBECONFIG=$(KIND_KUBECONFIG) kubectl annotate ManagedClusterAddon governance-policy-framework addon.open-cluster-management.io/on-multicluster-hub='true' -n $(MANAGED_CLUSTER_NAME)
-
-.PHONY: kind-deploy-addons-managed
-kind-deploy-addons-managed: ## Apply ManagedClusterAddon manifests to hub to deploy governance addons to a managed cluster.
+.PHONY: kind-deploy-addons
+kind-deploy-addons: ## Apply ManagedClusterAddon manifests to hub to deploy governance addons to a managed cluster.
 	@echo "Creating ManagedClusterAddon for managed cluster $(MANAGED_CLUSTER_NAME)"
 	KUBECONFIG=$(KIND_KUBECONFIG) kubectl apply -f test/resources/config_policy_addon_cr.yaml -n $(MANAGED_CLUSTER_NAME)
 	KUBECONFIG=$(KIND_KUBECONFIG) kubectl apply -f test/resources/framework_addon_cr.yaml -n $(MANAGED_CLUSTER_NAME)

--- a/README.md
+++ b/README.md
@@ -79,12 +79,16 @@ of that annotation makes it difficult to apply multiple changes - separate `kube
 commands will override each other, as opposed to being merged.
 
 To address this issue, there are some separate annotations that can be applied independently:
+
 - `addon.open-cluster-management.io/on-multicluster-hub` - set to "true" on the
-governance-policy-framework addon when deploying it on a self-managed hub. It has no effect on
-other addons.
+  governance-policy-framework addon when deploying it on a self-managed hub. It has no effect on
+  other addons. Alternatively, this annotation can be set on the hub's ManagedCluster object.
 - `log-level` - set to an integer to adjust the logging levels on the addon. A higher number will
-generate more logs. Note that logs from libraries used by the addon will be 2 levels below this
-setting; to get a `v=5` log message from a library, annotate the addon with `log-level=7`.
+  generate more logs. Note that logs from libraries used by the addon will be 2 levels below this
+  setting; to get a `v=5` log message from a library, annotate the addon with `log-level=7`.
+- `policy.open-cluster-management.io/sync-policies-on-multicluster-hub` - set this to "true" only
+  when the hub is imported by another hub. This is a very advanced use-case and should almost
+  never be used. Alternatively, this annotation can be set on the hub's ManagedCluster object.
 
 ## Getting Started - Development
 

--- a/build/manage-clusters.sh
+++ b/build/manage-clusters.sh
@@ -42,9 +42,14 @@ case ${RUN_MODE} in
     KIND_VERSION="${HUB_KIND_VERSION}" make kind-prep-ocm
     ;;
   deploy-addons)
-    make kind-deploy-addons-hub
+    make kind-deploy-addons
     ;;
 esac
+
+if [[ "${RUN_MODE}" == "create" || "${RUN_MODE}" == "create-dev" ]]; then
+  echo Annotating the ManagedCluster object to indicate it is a hub
+  KUBECONFIG="$PWD/$KIND_NAME.kubeconfig" kubectl annotate ManagedCluster $MANAGED_CLUSTER_NAME --overwrite "addon.open-cluster-management.io/on-multicluster-hub=true"
+fi
 
 # Deploy a variable number of managed clusters starting with cluster2
 for i in $(seq 2 $((MANAGED_CLUSTER_COUNT+1))); do
@@ -72,7 +77,7 @@ for i in $(seq 2 $((MANAGED_CLUSTER_COUNT+1))); do
     deploy-addons)
       # ManagedClusterAddon is applied to the hub
       export KIND_NAME="${KIND_PREFIX}1"
-      make kind-deploy-addons-managed
+      make kind-deploy-addons
       ;;
   esac
 done

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
           - --log-encoder={{ .Values.args.logEncoder }}
           - --log-level={{ .Values.args.logLevel }}
           - --v={{ .Values.args.pkgLogLevel }}
-          {{- if and (.Values.onMulticlusterHub) (ne .Values.installMode "Hosted") }}
+          {{- if and .Values.onMulticlusterHub (ne .Values.installMode "Hosted") (not .Values.args.syncPoliciesOnMulticlusterHub) }}
           - --disable-spec-sync=true
           {{- end }}
           {{- if eq .Values.installMode "Hosted" }}

--- a/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
@@ -11,6 +11,7 @@ args:
   logLevel: 0
   pkgLogLevel: -1
   logEncoder: console
+  syncPoliciesOnMulticlusterHub: false
 hubKubeConfigSecret: governance-policy-framework-hub-kubeconfig
 
 resources:


### PR DESCRIPTION
Normally, the spec sync is disabled if it's a self-managed hub. The caveat is when a hub is imported by another hub, the spec sync should still sync from the top-level hub.

Additionally, this allows the on-multicluster-hub annotation to be set on the ManagedCluster object instead of the addon directly.

Relates:
https://issues.redhat.com/browse/ACM-7150