### PR TITLE
Make the ManifestWork check more specific

### DIFF
--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -397,7 +397,10 @@ var _ = Describe("Test framework deployment", func() {
 			manifests, _, _ := unstructured.NestedSlice(mw.Object, "spec", "workload", "manifests")
 
 			for _, manifest := range manifests {
-				g.Expect(manifest.(map[string]interface{})["kind"]).ToNot(Equal("Namespace"))
+				if manifest.(map[string]interface{})["kind"] == "Namespace" {
+					nsName := manifest.(map[string]interface{})["metadata"].(map[string]interface{})["name"]
+					g.Expect(nsName).ToNot(Equal(cluster.clusterName))
+				}
 			}
 		}, 30, 5).Should(Succeed())
 


### PR DESCRIPTION
In commit e96042e, a change was made that made an unrelated test fail. This makes the test more specific to make it pass.