### PR TITLE
Allow configuring to emit error logs only

### DIFF
--- a/pkg/addon/common.go
+++ b/pkg/addon/common.go
@@ -200,8 +200,12 @@ func (pa *PolicyAgentAddon) Manifests(
 func GetLogLevel(component string, level string) int8 {
 	logDefault := int8(0)
 
+	if level == "error" {
+		return int8(-1)
+	}
+
 	logLevel, err := strconv.ParseInt(level, 10, 8)
-	if err != nil || logLevel < 0 {
+	if err != nil || logLevel < -1 {
 		log.Error(err, fmt.Sprintf(
 			"Failed to verify '%s' annotation value '%s' for component %s (falling back to default value %d)",
 			PolicyLogLevelAnnotation, level, component, logDefault),

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
           - '--leader-elect=false'
           {{- end }}
           - --log-encoder={{ .Values.args.logEncoder }}
-          - --log-level={{ .Values.args.logLevel }}
+          - --log-level={{ if eq (toString .Values.args.logLevel) "-1" }}error{{ else }}{{ .Values.args.logLevel }}{{end}}
           - --v={{ .Values.args.pkgLogLevel }}
           - --evaluation-concurrency={{ .Values.args.evaluationConcurrency }}
           - --client-max-qps={{ .Values.args.clientQPS }}

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
           - '--leader-elect=false'
           {{- end }}
           - --log-encoder={{ .Values.args.logEncoder }}
-          - --log-level={{ .Values.args.logLevel }}
+          - --log-level={{ if eq (toString .Values.args.logLevel) "-1" }}error{{ else }}{{ .Values.args.logLevel }}{{end}}
           - --v={{ .Values.args.pkgLogLevel }}
           {{- if and .Values.onMulticlusterHub (ne .Values.installMode "Hosted") (not .Values.args.syncPoliciesOnMulticlusterHub) }}
           - --disable-spec-sync=true


### PR DESCRIPTION
The controllers themselves already supported `--log-level=error`, but there was no way in the chart or via the annotation to use that setting. Now, a user can specify "error" or "-1" in the annotation to configure the controller to only emit error logs.

Refs:
 - https://issues.redhat.com/browse/ACM-7778