### PR TITLE
Bump addon framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ include build/common/Makefile.common.mk
 lint:
 
 .PHONY: fmt
+fmt:
 
 .PHONY: vet
 vet: ## Run go vet against code.
@@ -74,10 +75,6 @@ build: ## Build manager binary.
 # images section
 ############################################################
 
-ifndef ignore-not-found
-  ignore-not-found = false
-endif
-
 .PHONY: build-images
 build-images: generate fmt vet
 	@docker build -t ${IMAGE_NAME_AND_VERSION} -f build/Dockerfile .
@@ -88,7 +85,7 @@ build-images: generate fmt vet
 ############################################################
 
 .PHONY: clean
-clean: ## Clean up generated files.
+clean: kind-bootstrap-delete-clusters ## Clean up generated files.
 	-rm bin/*
 	-rm build/_output/bin/*
 	-rm coverage*.out
@@ -113,6 +110,7 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 ############################################################
 
 KUBEWAIT ?= $(PWD)/build/common/scripts/kubewait.sh
+ignore-not-found ?= false
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	k8s.io/apimachinery v0.26.10
 	k8s.io/client-go v0.26.10
 	k8s.io/component-base v0.26.10
-	open-cluster-management.io/addon-framework v0.6.1
-	open-cluster-management.io/api v0.11.0
+	open-cluster-management.io/addon-framework v0.8.0
+	open-cluster-management.io/api v0.12.0
 	sigs.k8s.io/controller-runtime v0.14.6
 )
 

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3i
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -1083,10 +1083,10 @@ k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20221107191617-1a15be271d1d/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-open-cluster-management.io/addon-framework v0.6.1 h1:gnBZaCRgtiPRjCBJoaRqMivajng/XOKp0NQhJUqLd+U=
-open-cluster-management.io/addon-framework v0.6.1/go.mod h1:Uu4XC3Ec0ATS7U73PJtzAP4NCDfbDBVy1k5RUUwQDqY=
-open-cluster-management.io/api v0.11.0 h1:zBxa33Co3wseLBF4HEJobhl0P6ygj+Drhe7Wrfo0/h8=
-open-cluster-management.io/api v0.11.0/go.mod h1:WgKUCJ7+Bf40DsOmH1Gdkpyj3joco+QLzrlM6Ak39zE=
+open-cluster-management.io/addon-framework v0.8.0 h1:i1OReMHuZIoAw2Q04SLjkieU25DnxYilzVZzBNyROwU=
+open-cluster-management.io/addon-framework v0.8.0/go.mod h1:20DP06VXhJ9RE1PetAMEQyeFCP7+nhs92pCAkqbWUOg=
+open-cluster-management.io/api v0.12.0 h1:sNkj4k2XyWA/GLsTiFg82bLIZ7JDZKkLLLyZjJUlJMs=
+open-cluster-management.io/api v0.12.0/go.mod h1:/CZhelEH+30/pX7vXGSZOzLMX0zvjthYOkT/5ZTzVTQ=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/addon/configpolicy/agent_addon.go
+++ b/pkg/addon/configpolicy/agent_addon.go
@@ -11,6 +11,7 @@ import (
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	"open-cluster-management.io/addon-framework/pkg/agent"
+	"open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -204,7 +205,7 @@ func GetAgentAddon(controllerContext *controllercmd.ControllerContext) (agent.Ag
 	}
 
 	return addonfactory.NewAgentAddonFactory(addonName, FS, "manifests/managedclusterchart").
-		WithConfigGVRs(addonfactory.AddOnDeploymentConfigGVR).
+		WithConfigGVRs(utils.AddOnDeploymentConfigGVR).
 		WithGetValuesFuncs(
 			addonfactory.GetAddOnDeploymentConfigValues(
 				addonfactory.NewAddOnDeploymentConfigGetter(addonClient),

--- a/pkg/addon/policyframework/agent_addon.go
+++ b/pkg/addon/policyframework/agent_addon.go
@@ -12,6 +12,7 @@ import (
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	"open-cluster-management.io/addon-framework/pkg/agent"
+	"open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -236,7 +237,7 @@ func GetAgentAddon(controllerContext *controllercmd.ControllerContext) (agent.Ag
 	}
 
 	return addonfactory.NewAgentAddonFactory(addonName, FS, "manifests/managedclusterchart").
-		WithConfigGVRs(addonfactory.AddOnDeploymentConfigGVR).
+		WithConfigGVRs(utils.AddOnDeploymentConfigGVR).
 		WithGetValuesFuncs(
 			addonfactory.GetAddOnDeploymentConfigValues(
 				addonfactory.NewAddOnDeploymentConfigGetter(addonClient),

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -16,14 +16,15 @@ import (
 )
 
 const (
-	case2ManagedClusterAddOnName  string = "config-policy-controller"
-	case2ManagedClusterAddOnCR    string = "../resources/config_policy_addon_cr.yaml"
-	case2ClusterManagementAddOnCR string = "../resources/config_policy_clustermanagementaddon.yaml"
-	case2DeploymentName           string = "config-policy-controller"
-	case2PodSelector              string = "app=config-policy-controller"
-	case2OpenShiftClusterClaim    string = "../resources/openshift_cluster_claim.yaml"
-	policyCrdName                 string = "policies.policy.open-cluster-management.io"
-	deletionOrphanAnnotationKey   string = "addon.open-cluster-management.io/deletion-orphan"
+	case2ManagedClusterAddOnName         string = "config-policy-controller"
+	case2ManagedClusterAddOnCR           string = "../resources/config_policy_addon_cr.yaml"
+	case2ClusterManagementAddOnCRDefault string = "../resources/config_policy_clustermanagementaddon.yaml"
+	case2ClusterManagementAddOnCR        string = "../resources/config_policy_clustermanagementaddon_config.yaml"
+	case2DeploymentName                  string = "config-policy-controller"
+	case2PodSelector                     string = "app=config-policy-controller"
+	case2OpenShiftClusterClaim           string = "../resources/openshift_cluster_claim.yaml"
+	policyCrdName                        string = "policies.policy.open-cluster-management.io"
+	deletionOrphanAnnotationKey          string = "addon.open-cluster-management.io/deletion-orphan"
 )
 
 func verifyConfigPolicyDeployment(
@@ -88,7 +89,17 @@ func verifyConfigPolicyDeployment(
 	}, 240, 1).Should(Equal(true))
 }
 
-var _ = Describe("Test config-policy-controller deployment", func() {
+var _ = Describe("Test config-policy-controller deployment", Ordered, func() {
+	BeforeAll(func() {
+		By("Deploying the default config-policy-controller ClusterManagementAddon to the hub cluster")
+		Kubectl("apply", "-f", case2ClusterManagementAddOnCRDefault)
+	})
+
+	AfterAll(func() {
+		By("Deleting the default config-policy-controller ClusterManagementAddon from the hub cluster")
+		Kubectl("delete", "-f", case2ClusterManagementAddOnCRDefault)
+	})
+
 	It("should create the default config-policy-controller deployment on the managed cluster", func() {
 		for i, cluster := range managedClusterList {
 			logPrefix := cluster.clusterType + " " + cluster.clusterName + ": "
@@ -115,8 +126,8 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 
 	It("should create a config-policy-controller deployment with node selector on the managed cluster", func() {
 		By("Creating the AddOnDeploymentConfig")
-		Kubectl("apply", "-f", addOnDeplomentConfigCR)
-		By("Creating the config-policy-controller ClusterManagementAddOn to use the AddOnDeploymentConfig")
+		Kubectl("apply", "-f", addOnDeploymentConfigCR)
+		By("Applying the config-policy-controller ClusterManagementAddOn to use the AddOnDeploymentConfig")
 		Kubectl("apply", "-f", case2ClusterManagementAddOnCR)
 
 		for i, cluster := range managedClusterList {
@@ -157,9 +168,9 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 		}
 
 		By("Deleting the AddOnDeploymentConfig")
-		Kubectl("delete", "-f", addOnDeplomentConfigCR, "--timeout=15s")
-		By("Deleting the config-policy-controller ClusterManagementAddOn to use the AddOnDeploymentConfig")
-		Kubectl("delete", "-f", case2ClusterManagementAddOnCR, "--timeout=15s")
+		Kubectl("delete", "-f", addOnDeploymentConfigCR, "--timeout=15s")
+		By("Restoring the default config-policy-controller ClusterManagementAddOn")
+		Kubectl("apply", "-f", case2ClusterManagementAddOnCRDefault)
 	})
 
 	It("should create the default config-policy-controller deployment in hosted mode", Label("hosted-mode"), func() {
@@ -211,8 +222,8 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 	It("should create the default config-policy-controller deployment in hosted mode in klusterlet agent namespace",
 		Label("hosted-mode"), func() {
 			By("Creating the AddOnDeploymentConfig")
-			Kubectl("apply", "-f", addOnDeplomentConfigWithCustomVarsCR)
-			By("Creating the config-policy-controller ClusterManagementAddOn to use the AddOnDeploymentConfig")
+			Kubectl("apply", "-f", addOnDeploymentConfigWithCustomVarsCR)
+			By("Applying the config-policy-controller ClusterManagementAddOn to use the AddOnDeploymentConfig")
 			Kubectl("apply", "-f", case2ClusterManagementAddOnCR)
 
 			for i, cluster := range managedClusterList[1:] {
@@ -283,9 +294,9 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 				Expect(namespace).To(BeNil())
 			}
 			By("Deleting the AddOnDeploymentConfig")
-			Kubectl("delete", "-f", addOnDeplomentConfigWithCustomVarsCR, "--timeout=15s")
-			By("Deleting the config-policy-controller ClusterManagementAddOn to use the AddOnDeploymentConfig")
-			Kubectl("delete", "-f", case2ClusterManagementAddOnCR, "--timeout=15s")
+			Kubectl("delete", "-f", addOnDeploymentConfigWithCustomVarsCR, "--timeout=15s")
+			By("Restoring the default config-policy-controller ClusterManagementAddOn")
+			Kubectl("apply", "-f", case2ClusterManagementAddOnCRDefault)
 		})
 
 	It("should create a config-policy-controller deployment with customizations", func() {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -21,14 +21,14 @@ import (
 )
 
 const (
-	addonNamespace                       string = "open-cluster-management-agent-addon"
-	kubeconfigFilename                   string = "../../kubeconfig_cluster"
-	loggingLevelAnnotation               string = "log-level=8"
-	evaluationConcurrencyAnnotation      string = "policy-evaluation-concurrency=5"
-	clientQPSAnnotation                  string = "client-qps=50"
-	prometheusEnabledAnnotation          string = "prometheus-metrics-enabled=true"
-	addOnDeplomentConfigCR               string = "../resources/addondeploymentconfig.yaml"
-	addOnDeplomentConfigWithCustomVarsCR string = "../resources/addondeploymentconfig_customvars.yaml"
+	addonNamespace                        string = "open-cluster-management-agent-addon"
+	kubeconfigFilename                    string = "../../kubeconfig_cluster"
+	loggingLevelAnnotation                string = "log-level=8"
+	evaluationConcurrencyAnnotation       string = "policy-evaluation-concurrency=5"
+	clientQPSAnnotation                   string = "client-qps=50"
+	prometheusEnabledAnnotation           string = "prometheus-metrics-enabled=true"
+	addOnDeploymentConfigCR               string = "../resources/addondeploymentconfig.yaml"
+	addOnDeploymentConfigWithCustomVarsCR string = "../resources/addondeploymentconfig_customvars.yaml"
 )
 
 var (

--- a/test/resources/config_policy_clustermanagementaddon.yaml
+++ b/test/resources/config_policy_clustermanagementaddon.yaml
@@ -2,10 +2,3 @@ apiVersion: addon.open-cluster-management.io/v1alpha1
 kind: ClusterManagementAddOn
 metadata:
   name: config-policy-controller
-spec:
-  supportedConfigs:
-  - group: addon.open-cluster-management.io
-    resource: addondeploymentconfigs
-    defaultConfig:
-      name: addon-default-placement
-      namespace: open-cluster-management

--- a/test/resources/config_policy_clustermanagementaddon_config.yaml
+++ b/test/resources/config_policy_clustermanagementaddon_config.yaml
@@ -1,0 +1,11 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: config-policy-controller
+spec:
+  supportedConfigs:
+  - group: addon.open-cluster-management.io
+    resource: addondeploymentconfigs
+    defaultConfig:
+      name: addon-default-placement
+      namespace: open-cluster-management

--- a/test/resources/framework_clustermanagementaddon.yaml
+++ b/test/resources/framework_clustermanagementaddon.yaml
@@ -2,10 +2,3 @@ apiVersion: addon.open-cluster-management.io/v1alpha1
 kind: ClusterManagementAddOn
 metadata:
   name: governance-policy-framework
-spec:
-  supportedConfigs:
-  - group: addon.open-cluster-management.io
-    resource: addondeploymentconfigs
-    defaultConfig:
-      name: addon-default-placement
-      namespace: open-cluster-management

--- a/test/resources/framework_clustermanagementaddon_config.yaml
+++ b/test/resources/framework_clustermanagementaddon_config.yaml
@@ -1,0 +1,11 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: governance-policy-framework
+spec:
+  supportedConfigs:
+  - group: addon.open-cluster-management.io
+    resource: addondeploymentconfigs
+    defaultConfig:
+      name: addon-default-placement
+      namespace: open-cluster-management


### PR DESCRIPTION
Upgrade `addon-framework` to `v0.8.0`
- It seems the `ClusterManagementAddon` CR became a hard prerequisite for the E2E tests, so it's also added here in the E2E suite. (I didn't pin down the exact commit where this occurred, but this seems to fit with the upstream documentation: https://github.com/open-cluster-management-io/open-cluster-management-io.github.io/blob/main/content/en/concepts/addon.md#add-on-enablement)

Also adds cluster cleanup to `clean` Make target.