### PR TITLE
Update framework permissions on listing secrets

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/role.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/role.yaml
@@ -43,6 +43,7 @@ rules:
   verbs:
   - delete
   - get
+  - list
   - update
 - apiGroups:
   - policy.open-cluster-management.io


### PR DESCRIPTION
Allow controllers in the framework to list secrets

ref: https://issues.redhat.com/browse/ACM-6869