### PR TITLE
Use the correct kubeconfig for hosted mode tests

### DIFF
--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cleanup_pod.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cleanup_pod.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "controller.fullname" . }}-uninstall
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ include "controller.fullname" . }}
+    app: {{ include "controller.fullname" . }}-uninstall
     chart: {{ include "controller.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/cleanup_pod.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/cleanup_pod.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "controller.fullname" . }}-uninstall
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ include "controller.fullname" . }}
+    app: {{ include "controller.fullname" . }}-uninstall
     chart: {{ include "controller.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -171,7 +171,9 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 				clusterName:   cluster.clusterName,
 				clusterType:   cluster.clusterType,
 				hostedOnHub:   true,
+				kubeconfig:    cluster.kubeconfig,
 			}
+
 			hubClusterConfig := managedClusterList[0]
 			hubClient := hubClusterConfig.clusterClient
 			installNamespace := fmt.Sprintf("%s-hosted", cluster.clusterName)
@@ -179,7 +181,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 
 			setupClusterSecretForHostedMode(
 				logPrefix, hubClient, "config-policy-controller-managed-kubeconfig",
-				string(hubKubeconfigInternal), installNamespace)
+				string(cluster.kubeconfig), installNamespace)
 
 			installAddonInHostedMode(
 				logPrefix, hubClient, case2ManagedClusterAddOnName,
@@ -223,6 +225,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 					clusterName:   cluster.clusterName,
 					clusterType:   cluster.clusterType,
 					hostedOnHub:   true,
+					kubeconfig:    cluster.kubeconfig,
 				}
 				hubClusterConfig := managedClusterList[0]
 				hubClient := hubClusterConfig.clusterClient
@@ -231,7 +234,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 
 				setupClusterSecretForHostedMode(
 					logPrefix, hubClient, "external-managed-kubeconfig",
-					string(hubKubeconfigInternal), installNamespace)
+					string(cluster.kubeconfig), installNamespace)
 
 				installAddonInHostedMode(
 					logPrefix, hubClient, case2ManagedClusterAddOnName,

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -53,6 +53,7 @@ type managedClusterConfig struct {
 	clusterType   string
 	// Only relevant for hosted mode tests.
 	hostedOnHub bool
+	kubeconfig  []byte
 }
 
 func TestE2e(t *testing.T) {
@@ -106,7 +107,14 @@ func getManagedClusters(client dynamic.Interface) []managedClusterConfig {
 			panic(err)
 		}
 
-		clusterClient := NewKubeClientDynamic("", fmt.Sprintf("%s%d_e2e", kubeconfigFilename, i+1), "")
+		kubeconfigPath := fmt.Sprintf("%s%d_e2e", kubeconfigFilename, i+1)
+
+		clusterClient := NewKubeClientDynamic("", kubeconfigPath, "")
+
+		kubeconfigContents, err := os.ReadFile(kubeconfigPath + "-internal")
+		if err != nil {
+			panic(err)
+		}
 
 		var clusterType string
 		if i == 0 {
@@ -120,6 +128,7 @@ func getManagedClusters(client dynamic.Interface) []managedClusterConfig {
 			clusterClient,
 			clusterType,
 			false,
+			kubeconfigContents,
 		}
 		clusters = append(clusters, newCluster)
 	}


### PR DESCRIPTION
This also changes the uninstall pod labels so they aren't tied to the main Deployment object due to the label selector matching.