### PR TITLE
Set OperatorPolicy default namespace option

### DIFF
--- a/pkg/addon/configpolicy/agent_addon.go
+++ b/pkg/addon/configpolicy/agent_addon.go
@@ -111,6 +111,11 @@ func getValues(cluster *clusterv1.ManagedCluster,
 	// Disable OperatorPolicy if the cluster is not on OpenShift version 4.y
 	userValues.OperatorPolicy["disabled"] = cluster.Labels["openshiftVersion-major"] != "4"
 
+	// Set the default namespace for OperatorPolicy for OpenShift 4
+	if cluster.Labels["openshiftVersion-major"] == "4" {
+		userValues.OperatorPolicy["default-namespace"] = "openshift-operators"
+	}
+
 	annotations := addon.GetAnnotations()
 
 	if val, ok := annotations[policyaddon.PolicyLogLevelAnnotation]; ok {

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -87,6 +87,9 @@ spec:
           {{- end }}
           {{- if not .Values.operatorPolicy.disabled }}
           - --enable-operator-policy=true
+          {{- if ne .Values.operatorPolicy.defaultNamespace "" }}
+          - --operator-policy-default-namespace={{ .Values.operatorPolicy.defaultNamespace }}
+          {{- end }}
           {{- end }}
         env:
           - name: WATCH_NAMESPACE

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_operatorpolicies_crd.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_operatorpolicies_crd.yaml
@@ -174,8 +174,6 @@ spec:
                         type: string
                     type: object
                   type: array
-              required:
-                - relatedObjects
               type: object
           type: object
       served: true

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
@@ -16,6 +16,7 @@ hubKubeConfigSecret: config-policy-controller-hub-kubeconfig
 
 operatorPolicy:
   disabled: false
+  defaultNamespace: ""
 
 resources:
   requests:

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -415,6 +415,7 @@ var _ = Describe("Test config-policy-controller deployment", Ordered, func() {
 						g.Expect(args).To(ContainElement("--client-max-qps=50"))
 						g.Expect(args).To(ContainElement("--leader-elect=false"))
 						g.Expect(args).To(ContainElement("--enable-operator-policy=true"))
+						g.Expect(args).ToNot(ContainElement(ContainSubstring("operator-policy-default-namespace")))
 					}
 				}
 			}, 180, 10).Should(Succeed())


### PR DESCRIPTION
This sets the command-line flag added by the companion PR https://github.com/open-cluster-management-io/config-policy-controller/pull/204

This only sets that flag when the managed cluster is using OpenShift v4. It should be noted that this flag is *not* currently configurable by the user (it is not for example exposed through an annotation).

Refs:
 - https://issues.redhat.com/browse/ACM-9896