### PR TITLE
Simplify actions; Upgrade `controller-gen`

### DIFF
--- a/.github/workflows/crd-sync.yml
+++ b/.github/workflows/crd-sync.yml
@@ -8,7 +8,6 @@ on:
 defaults:
   run:
     shell: bash
-    working-directory: governance-policy-addon-controller
 
 jobs:
   crd-sync-validation:
@@ -17,13 +16,11 @@ jobs:
     steps:
     - name: Checkout 
       uses: actions/checkout@v4
-      with:
-        path: governance-policy-addon-controller
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: governance-policy-addon-controller/go.mod
+        go-version-file: go.mod
 
     - name: Synchronize CRDs
       run: |

--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -7,12 +7,6 @@ on:
       - release-*
   workflow_dispatch: {}
 
-env:
-  GOPATH: '/home/runner/work/governance-policy-addon-controller/governance-policy-addon-controller/go'
-defaults:
-  run:
-    working-directory: go/src/open-cluster-management.io/governance-policy-addon-controller
-
 jobs:
   verify:
     name: images
@@ -20,13 +14,10 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          path: go/src/open-cluster-management.io/governance-policy-addon-controller
       - name: install Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go/src/open-cluster-management.io/governance-policy-addon-controller/go.mod
+          go-version-file: go.mod
       - name: images
         run: make build-images
       - name: push

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -7,9 +7,6 @@ on:
 
 env:
   TAG: ${{ github.ref_name }}
-defaults:
-  run:
-    working-directory: go/src/open-cluster-management.io/governance-policy-addon-controller
 
 jobs:
   release:
@@ -18,13 +15,10 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          path: go/src/open-cluster-management.io/governance-policy-addon-controller
       - name: install Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go/src/open-cluster-management.io/governance-policy-addon-controller/go.mod
+          go-version-file: go.mod
       - name: build images
         run:  |
           make build-images

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -11,7 +11,6 @@ on:
 defaults:
   run:
     shell: bash
-    working-directory: governance-policy-addon-controller
 
 jobs:
   kind-tests:
@@ -31,14 +30,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        path: governance-policy-addon-controller
-        fetch-depth: 0 # Fetch all history for all tags and branches
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: governance-policy-addon-controller/go.mod
+        go-version-file: go.mod
 
     - name: Create KinD Cluster (${{ matrix.kind }}) and deploy components
       env:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,7 +11,6 @@ on:
 defaults:
   run:
     shell: bash
-    working-directory: governance-policy-addon-controller
 
 jobs:
   linting-and-unit-tests:
@@ -20,14 +19,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        path: governance-policy-addon-controller
-        fetch-depth: 0 # Fetch all history for all tags and branches
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: governance-policy-addon-controller/go.mod
+        go-version-file: go.mod
 
     - name: Verify modules
       run: |

--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -3,7 +3,7 @@
 
 ## CLI versions (with links to the latest releases)
 # https://github.com/kubernetes-sigs/controller-tools/releases/latest
-CONTROLLER_GEN_VERSION := v0.6.1
+CONTROLLER_GEN_VERSION := v0.14.0
 # https://github.com/kubernetes-sigs/kustomize/releases/latest
 KUSTOMIZE_VERSION := v5.3.0
 # https://github.com/golangci/golangci-lint/releases/latest

--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -11,13 +11,13 @@ GOLANGCI_VERSION := v1.52.2
 # https://github.com/mvdan/gofumpt/releases/latest
 GOFUMPT_VERSION := v0.6.0
 # https://github.com/daixiang0/gci/releases/latest
-GCI_VERSION := v0.12.1
+GCI_VERSION := v0.12.3
 # https://github.com/securego/gosec/releases/latest
-GOSEC_VERSION := v2.18.2
+GOSEC_VERSION := v2.19.0
 # https://github.com/kubernetes-sigs/kubebuilder/releases/latest
-KBVERSION := 3.12.0
+KBVERSION := 3.14.0
 # https://github.com/kubernetes/kubernetes/releases/latest
-ENVTEST_K8S_VERSION := 1.26.x
+ENVTEST_K8S_VERSION := 1.29.x
 
 LOCAL_BIN ?= $(error LOCAL_BIN is not set.)
 ifneq ($(findstring $(LOCAL_BIN), $(PATH)), $(LOCAL_BIN))

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,9 +1,7 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: governance-policy-addon-controller
 rules:
 - apiGroups:

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_configurationpolicies_crd.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_configurationpolicies_crd.yaml
@@ -1,18 +1,16 @@
 # Copyright Contributors to the Open Cluster Management project
 
 {{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
-  name: configurationpolicies.policy.open-cluster-management.io
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
-    addon.open-cluster-management.io/hosted-manifest-location: hosting
     policy.open-cluster-management.io/policy-type: template
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+  name: configurationpolicies.policy.open-cluster-management.io
 spec:
   additionalPrinterColumns:
     - JSONPath: .status.compliant
@@ -25,17 +23,24 @@ spec:
     plural: configurationpolicies
     singular: configurationpolicy
   scope: Namespaced
-  subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       description: ConfigurationPolicy is the Schema for the configurationpolicies API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           type: object
@@ -43,19 +48,31 @@ spec:
           description: ConfigurationPolicySpec defines the desired state of ConfigurationPolicy
           properties:
             evaluationInterval:
-              description: Configures the minimum elapsed time before a ConfigurationPolicy is reevaluated. If the policy spec is changed, or if the list of namespaces selected by the policy changes, the policy may be evaluated regardless of the settings here.
+              description: |-
+                Configures the minimum elapsed time before a ConfigurationPolicy is reevaluated. If the policy
+                spec is changed, or if the list of namespaces selected by the policy changes, the policy may be
+                evaluated regardless of the settings here.
               properties:
                 compliant:
-                  description: The minimum elapsed time before a ConfigurationPolicy is reevaluated when in the compliant state. Set this to "never" to disable reevaluation when in the compliant state.
+                  description: |-
+                    The minimum elapsed time before a ConfigurationPolicy is reevaluated when in the compliant state. Set this to
+                    "never" to disable reevaluation when in the compliant state.
                   pattern: ^(?:(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))|never)+$
                   type: string
                 noncompliant:
-                  description: The minimum elapsed time before a ConfigurationPolicy is reevaluated when in the noncompliant state. Set this to "never" to disable reevaluation when in the noncompliant state.
+                  description: |-
+                    The minimum elapsed time before a ConfigurationPolicy is reevaluated when in the noncompliant state. Set this to
+                    "never" to disable reevaluation when in the noncompliant state.
                   pattern: ^(?:(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))|never)+$
                   type: string
               type: object
             namespaceSelector:
-              description: '''namespaceSelector'' defines the list of namespaces to include/exclude for objects defined in spec.objectTemplates. All selector rules are ANDed. If ''include'' is not provided but ''matchLabels'' and/or ''matchExpressions'' are, ''include'' will behave as if [''*''] were given. If ''matchExpressions'' and ''matchLabels'' are both not provided, ''include'' must be provided to retrieve namespaces.'
+              description: |-
+                'namespaceSelector' defines the list of namespaces to include/exclude for objects defined in
+                spec.objectTemplates. All selector rules are ANDed. If 'include' is not provided but
+                'matchLabels' and/or 'matchExpressions' are, 'include' will behave as if ['*'] were given. If
+                'matchExpressions' and 'matchLabels' are both not provided, 'include' must be provided to
+                retrieve namespaces.
               properties:
                 exclude:
                   description: '''exclude'' is an array of filepath expressions to exclude objects by name.'
@@ -72,16 +89,24 @@ spec:
                 matchExpressions:
                   description: '''matchExpressions'' is an array of label selector requirements matching objects by label.'
                   items:
-                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                    description: |-
+                      A label selector requirement is a selector that contains values, a key, and an operator that
+                      relates the key and values.
                     properties:
                       key:
                         description: key is the label key that the selector applies to.
                         type: string
                       operator:
-                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                        description: |-
+                          operator represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists and DoesNotExist.
                         type: string
                       values:
-                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                        description: |-
+                          values is an array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. This array is replaced during a strategic
+                          merge patch.
                         items:
                           type: string
                         type: array
@@ -97,7 +122,12 @@ spec:
                   type: object
               type: object
             object-templates:
-              description: '''object-templates'' and ''object-templates-raw'' are arrays of objects for the configuration policy to check, create, modify, or delete on the cluster. ''object-templates'' is an array of objects, while ''object-templates-raw'' is a string containing an array of objects in YAML format. Only one of the two object-templates variables can be set in a given configurationPolicy.'
+              description: |-
+                'object-templates' and 'object-templates-raw' are arrays of objects for the configuration
+                policy to check, create, modify, or delete on the cluster. 'object-templates' is an array
+                of objects, while 'object-templates-raw' is a string containing an array of objects in
+                YAML format. Only one of the two object-templates variables can be set in a given
+                configurationPolicy.
               items:
                 description: ObjectTemplate describes how an object should look
                 properties:
@@ -129,7 +159,9 @@ spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   recordDiff:
-                    description: RecordDiff specifies whether (and where) to log the diff between the object on the cluster and the objectDefinition in the policy. Defaults to "None".
+                    description: |-
+                      RecordDiff specifies whether (and where) to log the diff between the object on the
+                      cluster and the objectDefinition in the policy. Defaults to "None".
                     enum:
                       - Log
                       - None
@@ -140,10 +172,17 @@ spec:
                 type: object
               type: array
             object-templates-raw:
-              description: '''object-templates'' and ''object-templates-raw'' are arrays of objects for the configuration policy to check, create, modify, or delete on the cluster. ''object-templates'' is an array of objects, while ''object-templates-raw'' is a string containing an array of objects in YAML format. Only one of the two object-templates variables can be set in a given configurationPolicy.'
+              description: |-
+                'object-templates' and 'object-templates-raw' are arrays of objects for the configuration
+                policy to check, create, modify, or delete on the cluster. 'object-templates' is an array
+                of objects, while 'object-templates-raw' is a string containing an array of objects in
+                YAML format. Only one of the two object-templates variables can be set in a given
+                configurationPolicy.
               type: string
             pruneObjectBehavior:
-              description: PruneObjectBehavior is used to remove objects that are managed by the policy upon policy deletion.
+              description: |-
+                PruneObjectBehavior is used to remove objects that are managed by the
+                policy upon policy deletion.
               enum:
                 - DeleteAll
                 - DeleteIfCreated
@@ -240,16 +279,22 @@ spec:
                         description: API version of the referent.
                         type: string
                       kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        description: |-
+                          Kind of the referent. More info:
+                          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                         type: string
                       metadata:
                         description: Metadata values from the referent.
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            description: |-
+                              Name of the referent. More info:
+                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             type: string
                           namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            description: |-
+                              Namespace of the referent. More info:
+                              https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                             type: string
                         type: object
                     type: object
@@ -273,21 +318,13 @@ spec:
     - name: v1
       served: true
       storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{ else }}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     policy.open-cluster-management.io/policy-type: template
     addon.open-cluster-management.io/hosted-manifest-location: hosting
@@ -311,10 +348,19 @@ spec:
           description: ConfigurationPolicy is the Schema for the configurationpolicies API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -327,19 +373,31 @@ spec:
                     - object-templates-raw
               properties:
                 evaluationInterval:
-                  description: Configures the minimum elapsed time before a ConfigurationPolicy is reevaluated. If the policy spec is changed, or if the list of namespaces selected by the policy changes, the policy may be evaluated regardless of the settings here.
+                  description: |-
+                    Configures the minimum elapsed time before a ConfigurationPolicy is reevaluated. If the policy
+                    spec is changed, or if the list of namespaces selected by the policy changes, the policy may be
+                    evaluated regardless of the settings here.
                   properties:
                     compliant:
-                      description: The minimum elapsed time before a ConfigurationPolicy is reevaluated when in the compliant state. Set this to "never" to disable reevaluation when in the compliant state.
+                      description: |-
+                        The minimum elapsed time before a ConfigurationPolicy is reevaluated when in the compliant state. Set this to
+                        "never" to disable reevaluation when in the compliant state.
                       pattern: ^(?:(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))|never)+$
                       type: string
                     noncompliant:
-                      description: The minimum elapsed time before a ConfigurationPolicy is reevaluated when in the noncompliant state. Set this to "never" to disable reevaluation when in the noncompliant state.
+                      description: |-
+                        The minimum elapsed time before a ConfigurationPolicy is reevaluated when in the noncompliant state. Set this to
+                        "never" to disable reevaluation when in the noncompliant state.
                       pattern: ^(?:(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))|never)+$
                       type: string
                   type: object
                 namespaceSelector:
-                  description: '''namespaceSelector'' defines the list of namespaces to include/exclude for objects defined in spec.objectTemplates. All selector rules are ANDed. If ''include'' is not provided but ''matchLabels'' and/or ''matchExpressions'' are, ''include'' will behave as if [''*''] were given. If ''matchExpressions'' and ''matchLabels'' are both not provided, ''include'' must be provided to retrieve namespaces.'
+                  description: |-
+                    'namespaceSelector' defines the list of namespaces to include/exclude for objects defined in
+                    spec.objectTemplates. All selector rules are ANDed. If 'include' is not provided but
+                    'matchLabels' and/or 'matchExpressions' are, 'include' will behave as if ['*'] were given. If
+                    'matchExpressions' and 'matchLabels' are both not provided, 'include' must be provided to
+                    retrieve namespaces.
                   properties:
                     exclude:
                       description: '''exclude'' is an array of filepath expressions to exclude objects by name.'
@@ -356,16 +414,24 @@ spec:
                     matchExpressions:
                       description: '''matchExpressions'' is an array of label selector requirements matching objects by label.'
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
                         properties:
                           key:
                             description: key is the label key that the selector applies to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
                             items:
                               type: string
                             type: array
@@ -381,7 +447,12 @@ spec:
                       type: object
                   type: object
                 object-templates:
-                  description: '''object-templates'' and ''object-templates-raw'' are arrays of objects for the configuration policy to check, create, modify, or delete on the cluster. ''object-templates'' is an array of objects, while ''object-templates-raw'' is a string containing an array of objects in YAML format. Only one of the two object-templates variables can be set in a given configurationPolicy.'
+                  description: |-
+                    'object-templates' and 'object-templates-raw' are arrays of objects for the configuration
+                    policy to check, create, modify, or delete on the cluster. 'object-templates' is an array
+                    of objects, while 'object-templates-raw' is a string containing an array of objects in
+                    YAML format. Only one of the two object-templates variables can be set in a given
+                    configurationPolicy.
                   items:
                     description: ObjectTemplate describes how an object should look
                     properties:
@@ -413,7 +484,9 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       recordDiff:
-                        description: RecordDiff specifies whether (and where) to log the diff between the object on the cluster and the objectDefinition in the policy. Defaults to "None".
+                        description: |-
+                          RecordDiff specifies whether (and where) to log the diff between the object on the
+                          cluster and the objectDefinition in the policy. Defaults to "None".
                         enum:
                           - Log
                           - None
@@ -424,11 +497,18 @@ spec:
                     type: object
                   type: array
                 object-templates-raw:
-                  description: '''object-templates'' and ''object-templates-raw'' are arrays of objects for the configuration policy to check, create, modify, or delete on the cluster. ''object-templates'' is an array of objects, while ''object-templates-raw'' is a string containing an array of objects in YAML format. Only one of the two object-templates variables can be set in a given configurationPolicy.'
+                  description: |-
+                    'object-templates' and 'object-templates-raw' are arrays of objects for the configuration
+                    policy to check, create, modify, or delete on the cluster. 'object-templates' is an array
+                    of objects, while 'object-templates-raw' is a string containing an array of objects in
+                    YAML format. Only one of the two object-templates variables can be set in a given
+                    configurationPolicy.
                   type: string
                 pruneObjectBehavior:
                   default: None
-                  description: PruneObjectBehavior is used to remove objects that are managed by the policy upon policy deletion.
+                  description: |-
+                    PruneObjectBehavior is used to remove objects that are managed by the
+                    policy upon policy deletion.
                   enum:
                     - DeleteAll
                     - DeleteIfCreated
@@ -525,16 +605,22 @@ spec:
                             description: API version of the referent.
                             type: string
                           kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            description: |-
+                              Kind of the referent. More info:
+                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                             type: string
                           metadata:
                             description: Metadata values from the referent.
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                description: |-
+                                  Name of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 type: string
                               namespace:
-                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                description: |-
+                                  Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                                 type: string
                             type: object
                         type: object
@@ -557,10 +643,4 @@ spec:
       storage: true
       subresources:
         status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_operatorpolicies_crd.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_operatorpolicies_crd.yaml
@@ -1,14 +1,12 @@
 # Copyright Contributors to the Open Cluster Management project
 
 {{- if semverCompare "> 1.16.0" .Capabilities.KubeVersion.Version }}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     policy.open-cluster-management.io/policy-type: template
     addon.open-cluster-management.io/hosted-manifest-location: hosting
@@ -28,10 +26,19 @@ spec:
           description: OperatorPolicy is the Schema for the operatorpolicies API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -44,7 +51,10 @@ spec:
                     - musthave
                   type: string
                 operatorGroup:
-                  description: Include the name, namespace, and any `spec` fields for the OperatorGroup. For more info, see `kubectl explain operatorgroup.spec` or https://olm.operatorframework.io/docs/concepts/crds/operatorgroup/
+                  description: |-
+                    Include the name, namespace, and any `spec` fields for the OperatorGroup.
+                    For more info, see `kubectl explain operatorgroup.spec` or
+                    https://olm.operatorframework.io/docs/concepts/crds/operatorgroup/
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 remediationAction:
@@ -68,11 +78,16 @@ spec:
                     - Critical
                   type: string
                 subscription:
-                  description: Include the namespace, and any `spec` fields for the Subscription. For more info, see `kubectl explain subscription.spec` or https://olm.operatorframework.io/docs/concepts/crds/subscription/
+                  description: |-
+                    Include the namespace, and any `spec` fields for the Subscription.
+                    For more info, see `kubectl explain subscription.spec` or
+                    https://olm.operatorframework.io/docs/concepts/crds/subscription/
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 versions:
-                  description: Versions is a list of nonempty strings that specifies which installed versions are compliant when in 'inform' mode, and which installPlans are approved when in 'enforce' mode
+                  description: |-
+                    Versions is a list of nonempty strings that specifies which installed versions are compliant when
+                    in 'inform' mode, and which installPlans are approved when in 'enforce' mode
                   items:
                     minLength: 1
                     type: string
@@ -90,23 +105,35 @@ spec:
                 conditions:
                   description: Historic details on the condition of the policy
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}"
                     properties:
                       lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                         format: date-time
                         type: string
                       message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
                       reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
                         maxLength: 1024
                         minLength: 1
                         pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -119,7 +146,12 @@ spec:
                           - Unknown
                         type: string
                       type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
@@ -148,16 +180,22 @@ spec:
                             description: API version of the referent.
                             type: string
                           kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            description: |-
+                              Kind of the referent. More info:
+                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                             type: string
                           metadata:
                             description: Metadata values from the referent.
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                description: |-
+                                  Name of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 type: string
                               namespace:
-                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                description: |-
+                                  Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                                 type: string
                             type: object
                         type: object
@@ -180,10 +218,4 @@ spec:
       storage: true
       subresources:
         status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
@@ -1,15 +1,13 @@
 # Copyright Contributors to the Open Cluster Management project
 
 {{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.14.0
     {{ if .Values.onMulticlusterHub }}"addon.open-cluster-management.io/deletion-orphan": ""{{ end }}
-  creationTimestamp: null
   name: policies.policy.open-cluster-management.io
   labels:
     addon.open-cluster-management.io/hosted-manifest-location: hosting
@@ -33,17 +31,24 @@ spec:
       - plc
     singular: policy
   scope: Namespaced
-  subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       description: Policy is the Schema for the policies API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           type: object
@@ -51,15 +56,24 @@ spec:
           description: PolicySpec defines the desired state of Policy
           properties:
             copyPolicyMetadata:
-              description: If set to true (default), all the policy's labels and annotations will be copied to the replicated policy. If set to false, only the policy framework specific policy labels and annotations will be copied to the replicated policy.
+              description: |-
+                If set to true (default), all the policy's labels and annotations will be copied to the replicated policy.
+                If set to false, only the policy framework specific policy labels and annotations will be copied to the
+                replicated policy.
               type: boolean
             dependencies:
               description: PolicyDependencies that apply to each template in this Policy
               items:
-                description: Each PolicyDependency defines an object reference which must be in a certain compliance state before the policy should be created.
+                description: |-
+                  Each PolicyDependency defines an object reference which must be in a certain compliance
+                  state before the policy should be created.
                 properties:
                   apiVersion:
-                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                     type: string
                   compliance:
                     description: The ComplianceState (at path .status.compliant) required before the policy should be created
@@ -69,7 +83,12 @@ spec:
                       - NonCompliant
                     type: string
                   kind:
-                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                     type: string
                   name:
                     description: The name of the object to be checked
@@ -93,10 +112,16 @@ spec:
                   extraDependencies:
                     description: Additional PolicyDependencies that only apply to this template
                     items:
-                      description: Each PolicyDependency defines an object reference which must be in a certain compliance state before the policy should be created.
+                      description: |-
+                        Each PolicyDependency defines an object reference which must be in a certain compliance
+                        state before the policy should be created.
                       properties:
                         apiVersion:
-                          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          description: |-
+                            APIVersion defines the versioned schema of this representation of an object.
+                            Servers should convert recognized schemas to the latest internal value, and
+                            may reject unrecognized values.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                           type: string
                         compliance:
                           description: The ComplianceState (at path .status.compliant) required before the policy should be created
@@ -106,7 +131,12 @@ spec:
                             - NonCompliant
                           type: string
                         kind:
-                          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          description: |-
+                            Kind is a string value representing the REST resource this object represents.
+                            Servers may infer this from the endpoint the client submits requests to.
+                            Cannot be updated.
+                            In CamelCase.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                           type: string
                         name:
                           description: The name of the object to be checked
@@ -224,22 +254,14 @@ spec:
     - name: v1
       served: true
       storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{ else }}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.14.0
     {{ if .Values.onMulticlusterHub }}"addon.open-cluster-management.io/deletion-orphan": ""{{ end }}
-  creationTimestamp: null
   name: policies.policy.open-cluster-management.io
   labels:
     addon.open-cluster-management.io/hosted-manifest-location: hosting
@@ -270,10 +292,19 @@ spec:
           description: Policy is the Schema for the policies API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -281,12 +312,17 @@ spec:
               description: PolicySpec defines the desired state of Policy
               properties:
                 copyPolicyMetadata:
-                  description: If set to true (default), all the policy's labels and annotations will be copied to the replicated policy. If set to false, only the policy framework specific policy labels and annotations will be copied to the replicated policy.
+                  description: |-
+                    If set to true (default), all the policy's labels and annotations will be copied to the replicated policy.
+                    If set to false, only the policy framework specific policy labels and annotations will be copied to the
+                    replicated policy.
                   type: boolean
                 dependencies:
                   description: PolicyDependencies that apply to each template in this Policy
                   items:
-                    description: Each PolicyDependency defines an object reference which must be in a certain compliance state before the policy should be created.
+                    description: |-
+                      Each PolicyDependency defines an object reference which must be in a certain compliance
+                      state before the policy should be created.
                     oneOf:
                       - properties:
                           kind:
@@ -302,7 +338,11 @@ spec:
                               pattern: ^(?:(?:Certificate|Configuration|Iam)Policy)$
                     properties:
                       apiVersion:
-                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                         type: string
                       compliance:
                         description: The ComplianceState (at path .status.compliant) required before the policy should be created
@@ -312,7 +352,12 @@ spec:
                           - NonCompliant
                         type: string
                       kind:
-                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                         type: string
                       name:
                         description: The name of the object to be checked
@@ -336,7 +381,9 @@ spec:
                       extraDependencies:
                         description: Additional PolicyDependencies that only apply to this template
                         items:
-                          description: Each PolicyDependency defines an object reference which must be in a certain compliance state before the policy should be created.
+                          description: |-
+                            Each PolicyDependency defines an object reference which must be in a certain compliance
+                            state before the policy should be created.
                           oneOf:
                             - properties:
                                 kind:
@@ -352,7 +399,11 @@ spec:
                                     pattern: ^(?:(?:Certificate|Configuration|Iam)Policy)$
                           properties:
                             apiVersion:
-                              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                              description: |-
+                                APIVersion defines the versioned schema of this representation of an object.
+                                Servers should convert recognized schemas to the latest internal value, and
+                                may reject unrecognized values.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                               type: string
                             compliance:
                               description: The ComplianceState (at path .status.compliant) required before the policy should be created
@@ -362,7 +413,12 @@ spec:
                                 - NonCompliant
                               type: string
                             kind:
-                              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              description: |-
+                                Kind is a string value representing the REST resource this object represents.
+                                Servers may infer this from the endpoint the client submits requests to.
+                                Cannot be updated.
+                                In CamelCase.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                               type: string
                             name:
                               description: The name of the object to be checked
@@ -479,10 +535,4 @@ spec:
       storage: true
       subresources:
         status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}


### PR DESCRIPTION
Also adds a mutation function for `v1beta1` CRDs, since those are no longer supported for generation by `controller-gen`.

Relies on:
- https://github.com/open-cluster-management-io/config-policy-controller/pull/206
- https://github.com/open-cluster-management-io/governance-policy-propagator/pull/185
- https://github.com/open-cluster-management-io/governance-policy-propagator/pull/196