### PR TITLE
Create a real service account for auth with the compliance history API

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -157,6 +157,12 @@ rules:
   - watch
 - apiGroups:
   - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
+  - ""
   resourceNames:
   - governance-policy-database
   - policy-encryption-key
@@ -166,6 +172,36 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - open-cluster-management-compliance-history-api-recorder
+  resources:
+  - secrets
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - open-cluster-management-compliance-history-api-recorder
+  resources:
+  - serviceaccounts
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
 - apiGroups:
   - policy.open-cluster-management.io
   resources:
@@ -201,6 +237,7 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resourceNames:
+  - open-cluster-management:compliance-history-api-recorder
   - open-cluster-management:config-policy-controller-hub
   - open-cluster-management:policy-framework-hub
   resources:
@@ -219,6 +256,7 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resourceNames:
+  - open-cluster-management:compliance-history-api-recorder
   - open-cluster-management:config-policy-controller-hub
   - open-cluster-management:policy-framework-hub
   resources:

--- a/main.go
+++ b/main.go
@@ -56,9 +56,13 @@ import (
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;patch;update,resourceNames=governance-policy-framework;config-policy-controller
 
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;update;patch;delete,resourceNames="open-cluster-management:policy-framework-hub";"open-cluster-management:config-policy-controller-hub"
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;update;patch;delete,resourceNames="open-cluster-management:policy-framework-hub";"open-cluster-management:config-policy-controller-hub";"open-cluster-management:compliance-history-api-recorder"
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;update;patch;delete,resourceNames="open-cluster-management:policy-framework-hub";"open-cluster-management:config-policy-controller-hub"
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;update;patch;delete,resourceNames="open-cluster-management:policy-framework-hub";"open-cluster-management:config-policy-controller-hub";"open-cluster-management:compliance-history-api-recorder"
+//+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=create
+//+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;update;patch;delete,resourceNames="open-cluster-management-compliance-history-api-recorder"
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=create
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;update;patch;delete;watch;list,resourceNames="open-cluster-management-compliance-history-api-recorder"
 
 // Cannot limit based on resourceNames because the name is dynamic in hosted mode.
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=create;delete;get;list;patch;update;watch

--- a/pkg/addon/policyframework/agent_addon.go
+++ b/pkg/addon/policyframework/agent_addon.go
@@ -46,6 +46,11 @@ var agentPermissionFiles = []string{
 	"manifests/hubpermissions/role.yaml",
 	// rolebinding to bind the above role to a certain user group
 	"manifests/hubpermissions/rolebinding.yaml",
+	// a service account with minimal access for recording compliance events in the compliance history API
+	"manifests/hubpermissions/compliance_history_api_role.yaml",
+	"manifests/hubpermissions/compliance_history_api_rolebinding.yaml",
+	"manifests/hubpermissions/compliance_history_api_sa.yaml",
+	"manifests/hubpermissions/compliance_history_api_sa_secret.yaml",
 }
 
 type UserArgs struct {

--- a/pkg/addon/policyframework/manifests/hubpermissions/compliance_history_api_role.yaml
+++ b/pkg/addon/policyframework/manifests/hubpermissions/compliance_history_api_role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: open-cluster-management:compliance-history-api-recorder
+rules:
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policies/status
+  verbs:
+  - patch

--- a/pkg/addon/policyframework/manifests/hubpermissions/compliance_history_api_rolebinding.yaml
+++ b/pkg/addon/policyframework/manifests/hubpermissions/compliance_history_api_rolebinding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: open-cluster-management:compliance-history-api-recorder
+  namespace: "{{ .ClusterName }}"
+roleRef:
+  kind: ClusterRole
+  name: open-cluster-management:compliance-history-api-recorder
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: open-cluster-management-compliance-history-api-recorder
+    namespace: "{{ .ClusterName }}"

--- a/pkg/addon/policyframework/manifests/hubpermissions/compliance_history_api_sa.yaml
+++ b/pkg/addon/policyframework/manifests/hubpermissions/compliance_history_api_sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: open-cluster-management-compliance-history-api-recorder
+  namespace: "{{ .ClusterName }}"

--- a/pkg/addon/policyframework/manifests/hubpermissions/compliance_history_api_sa_secret.yaml
+++ b/pkg/addon/policyframework/manifests/hubpermissions/compliance_history_api_sa_secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: open-cluster-management-compliance-history-api-recorder
+  namespace: "{{ .ClusterName }}"
+  annotations:
+    kubernetes.io/service-account.name: open-cluster-management-compliance-history-api-recorder

--- a/pkg/addon/policyframework/manifests/hubpermissions/role.yaml
+++ b/pkg/addon/policyframework/manifests/hubpermissions/role.yaml
@@ -49,13 +49,14 @@ rules:
   - get
   - patch
   - update
-# Rule for secret-sync
+# Rule for secret-sync and compliance history API service account token
 - apiGroups:
   - ""
   resources:
   - secrets
   resourceNames:
   - policy-encryption-key
+  - open-cluster-management-compliance-history-api-recorder
   verbs:
   - get
   - list

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -43,6 +43,9 @@ var (
 	gvrSecret              schema.GroupVersionResource
 	gvrServiceMonitor      schema.GroupVersionResource
 	gvrService             schema.GroupVersionResource
+	gvrServiceAccount      schema.GroupVersionResource
+	gvrClusterRole         schema.GroupVersionResource
+	gvrRoleBinding         schema.GroupVersionResource
 	gvrPolicyCrd           schema.GroupVersionResource
 	managedClusterList     []managedClusterConfig
 	clientDynamic          dynamic.Interface
@@ -81,6 +84,13 @@ var _ = BeforeSuite(func() {
 		Group: "monitoring.coreos.com", Version: "v1", Resource: "servicemonitors",
 	}
 	gvrService = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+	gvrServiceAccount = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}
+	gvrClusterRole = schema.GroupVersionResource{
+		Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles",
+	}
+	gvrRoleBinding = schema.GroupVersionResource{
+		Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings",
+	}
 	gvrPolicyCrd = schema.GroupVersionResource{
 		Group:    "apiextensions.k8s.io",
 		Version:  "v1",


### PR DESCRIPTION
Related to https://github.com/open-cluster-management-io/governance-policy-framework-addon/pull/116

The addon framework's hub kubeconfig is certificate based. This does not allow authentication to the compliance history API using an OpenShift route that handles the TLS. Because of this, token based authentication is required.

The addon framework's generated hub kubeconfig to be used on the managed cluster is not of a real service account. It just creates a client certificate with a fake username and a list of groups. The RBAC is given to the groups. Because of this, no token can be generated for it. This approach creates a low privilege service account that allows a token to be retrieved by the status-sync controller to use for authentication with the compliance history API.

Relates:
https://issues.redhat.com/browse/ACM-6889