### PR TITLE
Fix OCM label check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ kind-approve-cluster: $(KIND_KUBECONFIG) ## Approve managed cluster in the kind 
 
 .PHONY: wait-for-work-agent
 wait-for-work-agent: $(KIND_KUBECONFIG) ## Wait for the klusterlet work agent to start.
-	KUBECONFIG=$(KIND_KUBECONFIG) $(KUBEWAIT) -r "pod -l=app=klusterlet-manifestwork-agent" -n open-cluster-management-agent -c condition=Ready -m 360
+	KUBECONFIG=$(KIND_KUBECONFIG) $(KUBEWAIT) -r "pod -l=app=klusterlet-agent" -n open-cluster-management-agent -c condition=Ready -m 360
 
 .PHONY: kind-run-local
 kind-run-local: manifests generate fmt vet $(KIND_KUBECONFIG) ## Run the policy-addon-controller locally against the kind cluster.

--- a/Makefile
+++ b/Makefile
@@ -269,11 +269,11 @@ e2e-stop-instrumented:
 .PHONY: e2e-debug
 e2e-debug: ## Collect debug logs from deployed clusters.
 	@echo "##### Gathering information from $(KIND_NAME) #####"
+	-KUBECONFIG=$(KIND_KUBECONFIG) kubectl get managedclusters
 	-KUBECONFIG=$(KIND_KUBECONFIG) kubectl get managedclusteraddons --all-namespaces
-	-KUBECONFIG=$(KIND_KUBECONFIG) kubectl -n $(CONTROLLER_NAMESPACE) get deployments
-	-KUBECONFIG=$(KIND_KUBECONFIG) kubectl -n $(CONTROLLER_NAMESPACE) get pods
-	-KUBECONFIG=$(KIND_KUBECONFIG) kubectl -n open-cluster-management-agent-addon get deployments
-	-KUBECONFIG=$(KIND_KUBECONFIG) kubectl -n open-cluster-management-agent-addon get pods
+	-KUBECONFIG=$(KIND_KUBECONFIG) kubectl -n $(CONTROLLER_NAMESPACE) get all
+	-KUBECONFIG=$(KIND_KUBECONFIG) kubectl -n open-cluster-management-agent get all
+	-KUBECONFIG=$(KIND_KUBECONFIG) kubectl -n open-cluster-management-agent-addon get all
 	-KUBECONFIG=$(KIND_KUBECONFIG) kubectl get manifestwork --all-namespaces -o yaml
 	
 	@echo "* Local controller log:"

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -35,6 +35,10 @@ var _ = Describe("Test framework deployment", Ordered, func() {
 	})
 
 	AfterAll(func() {
+		if CurrentSpecReport().Failed() {
+			debugCollection(case1PodSelector)
+		}
+
 		By("Deleting the default governance-policy-framework ClusterManagementAddon from the hub cluster")
 		Kubectl("delete", "-f", case1ClusterManagementAddOnCRDefault)
 	})

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -704,23 +704,21 @@ func checkContainersAndAvailabilityInNamespace(cluster managedClusterConfig, clu
 
 	if startupProbeInCluster(clusterIdx) {
 		By(logPrefix + "verifying all replicas in framework deployment are available")
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			deploy := GetWithTimeout(
 				client, gvrDeployment, case1DeploymentName, namespace, true, 60,
 			)
 
 			replicas, found, err := unstructured.NestedInt64(deploy.Object, "status", "replicas")
-			if !found || err != nil {
-				return false
-			}
+			g.Expect(found).To(BeTrue(), "status.replicas should exist in the deployment")
+			g.Expect(err).ToNot(HaveOccurred())
 
 			available, found, err := unstructured.NestedInt64(deploy.Object, "status", "availableReplicas")
-			if !found || err != nil {
-				return false
-			}
+			g.Expect(found).To(BeTrue(), "status.availableReplicas should exist in the deployment")
+			g.Expect(err).ToNot(HaveOccurred())
 
-			return available == replicas
-		}, 240, 1).Should(Equal(true))
+			g.Expect(available).To(Equal(replicas), "available replicas should equal expected replicas")
+		}, 240, 1).Should(Succeed())
 	}
 
 	By(logPrefix + "verifying one framework pod is running")

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -48,23 +48,21 @@ func verifyConfigPolicyDeployment(
 
 	if startupProbeInCluster(clusterNum) {
 		By(logPrefix + "verifying all replicas in config-policy-controller deployment are available")
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			deploy = GetWithTimeout(
 				client, gvrDeployment, case2DeploymentName, namespace, true, 30,
 			)
 
 			replicas, found, err := unstructured.NestedInt64(deploy.Object, "status", "replicas")
-			if !found || err != nil {
-				return false
-			}
+			g.Expect(found).To(BeTrue(), "status.replicas should exist in the deployment")
+			g.Expect(err).ToNot(HaveOccurred())
 
 			available, found, err := unstructured.NestedInt64(deploy.Object, "status", "availableReplicas")
-			if !found || err != nil {
-				return false
-			}
+			g.Expect(found).To(BeTrue(), "status.availableReplicas should exist in the deployment")
+			g.Expect(err).ToNot(HaveOccurred())
 
-			return available == replicas
-		}, 240, 1).Should(Equal(true))
+			g.Expect(available).To(Equal(replicas), "available replicas should equal expected replicas")
+		}, 240, 1).Should(Succeed())
 	}
 
 	By(logPrefix + "verifying a running config-policy-controller pod")

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -94,6 +94,10 @@ var _ = Describe("Test config-policy-controller deployment", Ordered, func() {
 	})
 
 	AfterAll(func() {
+		if CurrentSpecReport().Failed() {
+			debugCollection(case2PodSelector)
+		}
+
 		By("Deleting the default config-policy-controller ClusterManagementAddon from the hub cluster")
 		Kubectl("delete", "-f", case2ClusterManagementAddOnCRDefault)
 	})

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -145,19 +145,12 @@ func ListWithTimeoutByNamespace(
 
 	var list *unstructured.UnstructuredList
 
-	EventuallyWithOffset(1, func() error {
+	EventuallyWithOffset(1, func(g Gomega) {
 		var err error
 		list, err = clientHubDynamic.Resource(gvr).Namespace(ns).List(context.TODO(), opts)
-		if err != nil {
-			return err
-		}
-
-		if len(list.Items) != size {
-			return fmt.Errorf("list size doesn't match, expected %d actual %d", size, len(list.Items))
-		}
-
-		return nil
-	}, timeout, 1).ShouldNot(HaveOccurred())
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(list.Items).To(HaveLen(size))
+	}, timeout, 1).Should(Succeed())
 
 	if wantFound {
 		return list


### PR DESCRIPTION
Blocked by:
- https://github.com/open-cluster-management-io/ocm/pull/372

Summary:
- Adjusts the `klusterlet` Pod label while waiting for that Pod
- Cleans up E2E assertions to make it clearer what exactly is failing
- Adds a more elaborate set of debug logs for failures