### PR TITLE
Fix the addon controller on non-OCP clusters

### DIFF
--- a/main.go
+++ b/main.go
@@ -182,6 +182,8 @@ func runController(ctx context.Context, controllerContext *controllercmd.Control
 		wg.Add(1)
 
 		go func() {
+			defer wg.Done()
+
 			err := dynamicWatcher.Start(ctx)
 			if err != nil {
 				klog.Error(
@@ -189,8 +191,6 @@ func runController(ctx context.Context, controllerContext *controllercmd.Control
 				)
 				os.Exit(1)
 			}
-
-			wg.Done()
 		}()
 
 		klog.Info("Waiting for the dynamic watcher to start")
@@ -233,13 +233,16 @@ func runController(ctx context.Context, controllerContext *controllercmd.Control
 	wg.Add(1)
 
 	go func() {
+		defer wg.Done()
+
 		err = mgr.Start(ctx)
 		if err != nil {
 			klog.Error(err, "problem starting manager")
 			os.Exit(1)
 		}
 
-		wg.Done()
+		// mgr.Start is not blocking so wait on the context to finish
+		<-ctx.Done()
 	}()
 
 	wg.Wait()


### PR DESCRIPTION
The addon controller would exit prematurely if there wasn't the ComplianceDBSecretReconciler running to keep an active wait group.