### PR TITLE
Add the watch permission on policy-encryption-key on managed

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/role.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/role.yaml
@@ -45,6 +45,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - policy.open-cluster-management.io
   resources:


### PR DESCRIPTION
Recently, the managed cluster client in the governance-policy-framework started using a controller-runtime cached client. This requires the watch permission or else errors such as the following are displayed in the governance-policy-framework logs:

Failed to watch *v1.Secret: unknown (get secrets)

Relates:
https://issues.redhat.com/browse/ACM-12447