### PR TITLE
Make CRD descriptions folded

### DIFF
--- a/build/crd-sync.sh
+++ b/build/crd-sync.sh
@@ -1,48 +1,68 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail  # exit on errors and unset vars, and stop on the first error in a "pipeline"
+set -euxo pipefail # exit on errors and unset vars, and stop on the first error in a "pipeline"
 
 ORG=${ORG:-"open-cluster-management-io"}
 BRANCH=${BRANCH:-"main"}
 
+# Fix sed issues on mac by using GSED
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+SED="sed"
+if [ "${OS}" == "darwin" ]; then
+  SED="gsed"
+  if [ ! -x "$(command -v ${SED})" ]; then
+    echo "ERROR: ${SED} required, but not found."
+    echo 'Perform "brew install gnu-sed" and try again.'
+    exit 1
+  fi
+fi
+
 mkdir -p .go
 
 # Clone repositories containing the CRD definitions
-for REPO in config-policy-controller governance-policy-propagator
-do
+for REPO in config-policy-controller governance-policy-propagator; do
     # Try a given ORG/BRANCH, but fall back to the open-cluster-management-io org on the main branch if it fails
-    git clone -b "${BRANCH}" --depth 1 https://github.com/${ORG}/${REPO}.git .go/${REPO} \
-    || git clone -b main --depth 1 https://github.com/open-cluster-management-io/${REPO}.git .go/${REPO}
+    git clone -b "${BRANCH}" --depth 1 https://github.com/${ORG}/${REPO}.git .go/${REPO} ||
+        git clone -b main --depth 1 https://github.com/open-cluster-management-io/${REPO}.git .go/${REPO}
 done
 
 generate_v1beta1() {
     CRD_PATH=${1}
-    yq '.apiVersion += "beta1"' -i ${CRD_PATH}
-    yq '.spec.version = "v1"' -i ${CRD_PATH}
-    yq '.spec.additionalPrinterColumns = .spec.versions[].additionalPrinterColumns' -i ${CRD_PATH}
-    yq '.spec.additionalPrinterColumns[] |= .JSONPath = .jsonPath' -i ${CRD_PATH}
-    yq 'del(.spec.additionalPrinterColumns[].jsonPath)' -i ${CRD_PATH}
-    yq '.spec.validation = .spec.versions[].schema' -i ${CRD_PATH}
-    yq '.spec.subresources.status = {}' -i ${CRD_PATH}
-    yq '.spec.versions = [{"name": "v1", "served": true, "storage": true}]' -i ${CRD_PATH}
-    yq 'del(.. | select(has("default")).default)' -i ${CRD_PATH}
-    yq 'del(.. | select(has("oneOf")).oneOf)' -i ${CRD_PATH}
-    yq 'sort_keys(..)' -i ${CRD_PATH}
+    yq '.apiVersion += "beta1"' -i "${CRD_PATH}"
+    yq '.spec.version = "v1"' -i "${CRD_PATH}"
+    yq '.spec.additionalPrinterColumns = .spec.versions[].additionalPrinterColumns' -i "${CRD_PATH}"
+    yq '.spec.additionalPrinterColumns[] |= .JSONPath = .jsonPath' -i "${CRD_PATH}"
+    yq 'del(.spec.additionalPrinterColumns[].jsonPath)' -i "${CRD_PATH}"
+    yq '.spec.validation = .spec.versions[].schema' -i "${CRD_PATH}"
+    yq '.spec.subresources.status = {}' -i "${CRD_PATH}"
+    yq '.spec.versions = [{"name": "v1", "served": true, "storage": true}]' -i "${CRD_PATH}"
+    yq 'del(.. | select(has("default")).default)' -i "${CRD_PATH}"
+    yq 'del(.. | select(has("oneOf")).oneOf)' -i "${CRD_PATH}"
+    yq 'sort_keys(..)' -i "${CRD_PATH}"
+}
+
+format_descriptions() {
+    crd_path=${1}
+
+    ${SED} -i 's/ description: |-/ description: >-/g' "${crd_path}"
 }
 
 (
     cd .go/config-policy-controller
     # ConfigurationPolicy CRD
+    format_descriptions deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml
     cp deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml ../config-policy-crd-v1.yaml
     cp deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml ../config-policy-crd-v1beta1.yaml
     generate_v1beta1 ../config-policy-crd-v1beta1.yaml
     # OperatorPolicy CRD (v1beta1 not required since it's not supported on earlier K8s)
+    format_descriptions deploy/crds/policy.open-cluster-management.io_operatorpolicies.yaml
     cp deploy/crds/policy.open-cluster-management.io_operatorpolicies.yaml ../operator-policy-crd-v1.yaml
 )
 
 (
     cd .go/governance-policy-propagator
     # Policy CRD
+    format_descriptions deploy/crds/policy.open-cluster-management.io_policies.yaml
     cp deploy/crds/policy.open-cluster-management.io_policies.yaml ../policy-crd-v1.yaml
     cp deploy/crds/policy.open-cluster-management.io_policies.yaml ../policy-crd-v1beta1.yaml
     generate_v1beta1 ../policy-crd-v1beta1.yaml
@@ -55,12 +75,12 @@ crdPrefix='# Copyright Contributors to the Open Cluster Management project
 addLocationLabel='.metadata.labels += {"addon.open-cluster-management.io/hosted-manifest-location": "hosting"}'
 addTemplateLabel='.metadata.labels += {"policy.open-cluster-management.io/policy-type": "template"}'
 
-# This annotation must *only* be added on the hub cluster. On others, we want the CRD removed. 
+# This annotation must *only* be added on the hub cluster. On others, we want the CRD removed.
 # This kind of condition is not valid YAML on its own, so it has to be hacked in.
 addTempAnnotation='.metadata.annotations += {"SEDTARGET": "SEDTARGET"}'
 replaceAnnotation='s/SEDTARGET: SEDTARGET/{{ if .Values.onMulticlusterHub }}"addon.open-cluster-management.io\/deletion-orphan": ""{{ end }}/g'
 
-cat > pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_configurationpolicies_crd.yaml << EOF
+cat >pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_configurationpolicies_crd.yaml <<EOF
 ${crdPrefix}
 $(yq e "$addLocationLabel | $addTemplateLabel" .go/config-policy-crd-v1beta1.yaml)
 {{ else }}
@@ -68,13 +88,13 @@ $(yq e "$addLocationLabel" .go/config-policy-crd-v1.yaml)
 {{- end }}
 EOF
 
-cat > pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_operatorpolicies_crd.yaml << EOF
+cat >pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_operatorpolicies_crd.yaml <<EOF
 $(echo "${crdPrefix}" | sed 's/</>/')
 $(yq e "$addLocationLabel" .go/operator-policy-crd-v1.yaml)
 {{- end }}
 EOF
 
-cat > pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml << EOF
+cat >pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml <<EOF
 ${crdPrefix}
 $(yq e "$addTempAnnotation | $addLocationLabel" .go/policy-crd-v1beta1.yaml | sed -E "$replaceAnnotation")
 {{ else }}
@@ -83,8 +103,7 @@ $(yq e "$addTempAnnotation | $addLocationLabel" .go/policy-crd-v1.yaml | sed -E 
 EOF
 
 # Clean up the repositories - the chmod is necessary because Go makes some read-only things.
-for REPO in config-policy-controller governance-policy-propagator
-do
+for REPO in config-policy-controller governance-policy-propagator; do
     chmod -R +rw .go/${REPO}
     rm -rf .go/${REPO}
 done

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_configurationpolicies_crd.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_configurationpolicies_crd.yaml
@@ -27,64 +27,41 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: |-
-        ConfigurationPolicy is the schema for the configurationpolicies API. A configuration policy
-        contains, in whole or in part, an object definition to compare with objects on the cluster. If
-        the definition of the configuration policy doesn't match the objects on the cluster, a
-        noncompliant status is displayed. Furthermore, if the RemediationAction is set to `enforce` and
-        the name of the object is available, the configuration policy controller creates or updates the
-        object to match in order to make the configuration policy compliant.
+      description: >-
+        ConfigurationPolicy is the schema for the configurationpolicies API. A configuration policy contains, in whole or in part, an object definition to compare with objects on the cluster. If the definition of the configuration policy doesn't match the objects on the cluster, a noncompliant status is displayed. Furthermore, if the RemediationAction is set to `enforce` and the name of the object is available, the configuration policy controller creates or updates the object to match in order to make the configuration policy compliant.
       properties:
         apiVersion:
-          description: |-
-            APIVersion defines the versioned schema of this representation of an object.
-            Servers should convert recognized schemas to the latest internal value, and
-            may reject unrecognized values.
-            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+          description: >-
+            APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: |-
-            Kind is a string value representing the REST resource this object represents.
-            Servers may infer this from the endpoint the client submits requests to.
-            Cannot be updated.
-            In CamelCase.
-            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+          description: >-
+            Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           type: object
         spec:
-          description: |-
-            ConfigurationPolicySpec defines the desired configuration of objects on the cluster, along with
-            how the controller should handle when the cluster doesn't match the configuration policy.
+          description: >-
+            ConfigurationPolicySpec defines the desired configuration of objects on the cluster, along with how the controller should handle when the cluster doesn't match the configuration policy.
           properties:
             evaluationInterval:
-              description: |-
-                EvaluationInterval configures the minimum elapsed time before a configuration policy is
-                reevaluated. The default value is `watch` to leverage Kubernetes API watches instead of polling the Kubernetes API
-                server. If the policy spec is changed or if the list of namespaces selected by the policy changes, the policy might
-                be evaluated regardless of the settings here.
+              description: >-
+                EvaluationInterval configures the minimum elapsed time before a configuration policy is reevaluated. The default value is `watch` to leverage Kubernetes API watches instead of polling the Kubernetes API server. If the policy spec is changed or if the list of namespaces selected by the policy changes, the policy might be evaluated regardless of the settings here.
               properties:
                 compliant:
-                  description: |-
-                    Compliant is the minimum elapsed time before a configuration policy is reevaluated when in the
-                    compliant state. Set this to `never` to disable reevaluation when in the compliant state. The default value is
-                    `watch`.
+                  description: >-
+                    Compliant is the minimum elapsed time before a configuration policy is reevaluated when in the compliant state. Set this to `never` to disable reevaluation when in the compliant state. The default value is `watch`.
                   pattern: ^(?:(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))|never|watch)+$
                   type: string
                 noncompliant:
-                  description: |-
-                    NonCompliant is the minimum elapsed time before a configuration policy is reevaluated when in the noncompliant
-                    state. Set this to `never` to disable reevaluation when in the noncompliant state. The default value is `watch`.
+                  description: >-
+                    NonCompliant is the minimum elapsed time before a configuration policy is reevaluated when in the noncompliant state. Set this to `never` to disable reevaluation when in the noncompliant state. The default value is `watch`.
                   pattern: ^(?:(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))|never|watch)+$
                   type: string
               type: object
             namespaceSelector:
-              description: |-
-                NamespaceSelector defines the list of namespaces to include or exclude for objects defined in
-                `spec["object-templates"]`. All selector rules are combined. If 'include' is not provided but
-                `matchLabels` and/or `matchExpressions` are, `include` will behave as if `['*']` were given. If
-                `matchExpressions` and `matchLabels` are both not provided, `include` must be provided to
-                retrieve namespaces.
+              description: >-
+                NamespaceSelector defines the list of namespaces to include or exclude for objects defined in `spec["object-templates"]`. All selector rules are combined. If 'include' is not provided but `matchLabels` and/or `matchExpressions` are, `include` will behave as if `['*']` were given. If `matchExpressions` and `matchLabels` are both not provided, `include` must be provided to retrieve namespaces.
               properties:
                 exclude:
                   description: Exclude is an array of filepath expressions to exclude objects by name.
@@ -101,24 +78,19 @@ spec:
                 matchExpressions:
                   description: MatchExpressions is an array of label selector requirements matching objects by label.
                   items:
-                    description: |-
-                      A label selector requirement is a selector that contains values, a key, and an operator that
-                      relates the key and values.
+                    description: >-
+                      A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                     properties:
                       key:
                         description: key is the label key that the selector applies to.
                         type: string
                       operator:
-                        description: |-
-                          operator represents a key's relationship to a set of values.
-                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                        description: >-
+                          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                         type: string
                       values:
-                        description: |-
-                          values is an array of string values. If the operator is In or NotIn,
-                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                          the values array must be empty. This array is replaced during a strategic
-                          merge patch.
+                        description: >-
+                          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                         items:
                           type: string
                         type: array
@@ -134,21 +106,14 @@ spec:
                   type: object
               type: object
             object-templates:
-              description: |-
-                The `object-templates` is an array of object configurations for the configuration policy to
-                check, create, modify, or delete objects on the cluster. Keys inside of the objectDefinition in
-                an object template may point to values that have Go templates. For more advanced Go templating
-                such as `range` loops and `if` conditionals, use `object-templates-raw`. Only one of
-                `object-templates` and `object-templates-raw` can be set in a configuration policy. For more on
-                the Go templates, see https://github.com/stolostron/go-template-utils/blob/main/README.md.
+              description: >-
+                The `object-templates` is an array of object configurations for the configuration policy to check, create, modify, or delete objects on the cluster. Keys inside of the objectDefinition in an object template may point to values that have Go templates. For more advanced Go templating such as `range` loops and `if` conditionals, use `object-templates-raw`. Only one of `object-templates` and `object-templates-raw` can be set in a configuration policy. For more on the Go templates, see https://github.com/stolostron/go-template-utils/blob/main/README.md.
               items:
                 description: ObjectTemplate describes the desired state of an object on the cluster.
                 properties:
                   complianceType:
-                    description: |-
-                      ComplianceType describes how objects on the cluster should be compared with the object definition
-                      of the configuration policy. The supported options are `MustHave`, `MustOnlyHave`, or
-                      `MustNotHave`.
+                    description: >-
+                      ComplianceType describes how objects on the cluster should be compared with the object definition of the configuration policy. The supported options are `MustHave`, `MustOnlyHave`, or `MustNotHave`.
                     enum:
                       - MustHave
                       - Musthave
@@ -161,11 +126,8 @@ spec:
                       - mustnothave
                     type: string
                   metadataComplianceType:
-                    description: |-
-                      MetadataComplianceType describes how the labels and annotations of objects on the cluster should
-                      be compared with the object definition of the configuration policy. The supported options are
-                      `MustHave` or `MustOnlyHave`. The default value is the value defined in `complianceType` for the
-                      object template.
+                    description: >-
+                      MetadataComplianceType describes how the labels and annotations of objects on the cluster should be compared with the object definition of the configuration policy. The supported options are `MustHave` or `MustOnlyHave`. The default value is the value defined in `complianceType` for the object template.
                     enum:
                       - MustHave
                       - Musthave
@@ -179,26 +141,16 @@ spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   recordDiff:
-                    description: |-
-                      RecordDiff specifies whether and where to log the difference between the object on the cluster
-                      and the `objectDefinition` parameter in the policy. The supported options are `InStatus` to
-                      record the difference in the policy status field, `Log` to log the difference in the
-                      `config-policy-controller` pod, and `None` to not log the difference. The default value is
-                      `None` for object kinds that include sensitive data such as `ConfigMap`, `OAuthAccessToken`,
-                      `OAuthAuthorizeTokens`, `Route`, and `Secret`, or when a templated `objectDefinition`
-                      references sensitive data. For all other kinds, the default value is `InStatus`.
+                    description: >-
+                      RecordDiff specifies whether and where to log the difference between the object on the cluster and the `objectDefinition` parameter in the policy. The supported options are `InStatus` to record the difference in the policy status field, `Log` to log the difference in the `config-policy-controller` pod, and `None` to not log the difference. The default value is `None` for object kinds that include sensitive data such as `ConfigMap`, `OAuthAccessToken`, `OAuthAuthorizeTokens`, `Route`, and `Secret`, or when a templated `objectDefinition` references sensitive data. For all other kinds, the default value is `InStatus`.
                     enum:
                       - Log
                       - InStatus
                       - None
                     type: string
                   recreateOption:
-                    description: |-
-                      RecreateOption describes when to delete and recreate an object when an update is required. When you set the
-                      object to `IfRequired`, the policy recreates the object when updating an immutable field. When you set the
-                      parameter to `Always`, the policy recreates the object on any update. When you set the `remediationAction` to
-                      `inform`, the parameter value, `recreateOption`, has no effect on the object. The `IfRequired` value has no
-                      effect on clusters without dry-run update support. The default value is `None`.
+                    description: >-
+                      RecreateOption describes when to delete and recreate an object when an update is required. When you set the object to `IfRequired`, the policy recreates the object when updating an immutable field. When you set the parameter to `Always`, the policy recreates the object on any update. When you set the `remediationAction` to `inform`, the parameter value, `recreateOption`, has no effect on the object. The `IfRequired` value has no effect on clusters without dry-run update support. The default value is `None`.
                     enum:
                       - None
                       - IfRequired
@@ -210,26 +162,20 @@ spec:
                 type: object
               type: array
             object-templates-raw:
-              description: |-
-                The `object-templates-raw` is a string containing Go templates that must ultimately produce an
-                array of object configurations in YAML format to be used as `object-templates`. Only one of
-                `object-templates` and `object-templates-raw` can be set in a configuration policy. For more on
-                the Go templates, see https://github.com/stolostron/go-template-utils/blob/main/README.md.
+              description: >-
+                The `object-templates-raw` is a string containing Go templates that must ultimately produce an array of object configurations in YAML format to be used as `object-templates`. Only one of `object-templates` and `object-templates-raw` can be set in a configuration policy. For more on the Go templates, see https://github.com/stolostron/go-template-utils/blob/main/README.md.
               type: string
             pruneObjectBehavior:
-              description: |-
-                PruneObjectBehavior is used to remove objects that are managed by the policy upon either case: a
-                change to the policy that causes an object to no longer be managed by the policy, or the deletion
-                of the policy.
+              description: >-
+                PruneObjectBehavior is used to remove objects that are managed by the policy upon either case: a change to the policy that causes an object to no longer be managed by the policy, or the deletion of the policy.
               enum:
                 - DeleteAll
                 - DeleteIfCreated
                 - None
               type: string
             remediationAction:
-              description: |-
-                RemediationAction is the remediation of the policy. The parameter values are `enforce` and
-                `inform`.
+              description: >-
+                RemediationAction is the remediation of the policy. The parameter values are `enforce` and `inform`.
               enum:
                 - Inform
                 - inform
@@ -237,9 +183,8 @@ spec:
                 - enforce
               type: string
             severity:
-              description: |-
-                Severity is a user-defined severity for when an object is noncompliant with this configuration
-                policy. The supported options are `low`, `medium`, `high`, and `critical`.
+              description: >-
+                Severity is a user-defined severity for when an object is noncompliant with this configuration policy. The supported options are `low`, `medium`, `high`, and `critical`.
               enum:
                 - low
                 - Low
@@ -254,14 +199,12 @@ spec:
             - remediationAction
           type: object
         status:
-          description: |-
-            ConfigurationPolicyStatus is the observed status of the configuration policy from its object
-            definitions.
+          description: >-
+            ConfigurationPolicyStatus is the observed status of the configuration policy from its object definitions.
           properties:
             compliancyDetails:
-              description: |-
-                CompliancyDetails is a list of statuses matching one-to-one with each of the items in the
-                `object-templates` array.
+              description: >-
+                CompliancyDetails is a list of statuses matching one-to-one with each of the items in the `object-templates` array.
               items:
                 description: TemplateStatus reports the compliance details from the definitions in an `object-template`.
                 properties:
@@ -320,15 +263,13 @@ spec:
               description: LastEvaluated is an ISO-8601 timestamp of the last time the policy was evaluated.
               type: string
             lastEvaluatedGeneration:
-              description: |-
-                LastEvaluatedGeneration is the generation of the ConfigurationPolicy object when it was last
-                evaluated.
+              description: >-
+                LastEvaluatedGeneration is the generation of the ConfigurationPolicy object when it was last evaluated.
               format: int64
               type: integer
             relatedObjects:
-              description: |-
-                RelatedObjects is a list of objects processed by the configuration policy due to its
-                `object-templates`.
+              description: >-
+                RelatedObjects is a list of objects processed by the configuration policy due to its `object-templates`.
               items:
                 description: RelatedObject contains the details of an object matched by the policy.
                 properties:
@@ -359,19 +300,16 @@ spec:
                     description: Properties are additional properties of the related object relevant to the configuration policy.
                     properties:
                       createdByPolicy:
-                        description: |-
-                          CreatedByPolicy reports whether the object was created by the configuration policy, which is
-                          important when pruning is configured.
+                        description: >-
+                          CreatedByPolicy reports whether the object was created by the configuration policy, which is important when pruning is configured.
                         type: boolean
                       diff:
-                        description: |-
-                          Diff stores the difference between the `objectDefinition` in the policy and the object on the
-                          cluster.
+                        description: >-
+                          Diff stores the difference between the `objectDefinition` in the policy and the object on the cluster.
                         type: string
                       uid:
-                        description: |-
-                          UID stores the object UID to help track object ownership for deletion when pruning is
-                          configured.
+                        description: >-
+                          UID stores the object UID to help track object ownership for deletion when pruning is configured.
                         type: string
                     type: object
                   reason:
@@ -413,35 +351,22 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: |-
-            ConfigurationPolicy is the schema for the configurationpolicies API. A configuration policy
-            contains, in whole or in part, an object definition to compare with objects on the cluster. If
-            the definition of the configuration policy doesn't match the objects on the cluster, a
-            noncompliant status is displayed. Furthermore, if the RemediationAction is set to `enforce` and
-            the name of the object is available, the configuration policy controller creates or updates the
-            object to match in order to make the configuration policy compliant.
+          description: >-
+            ConfigurationPolicy is the schema for the configurationpolicies API. A configuration policy contains, in whole or in part, an object definition to compare with objects on the cluster. If the definition of the configuration policy doesn't match the objects on the cluster, a noncompliant status is displayed. Furthermore, if the RemediationAction is set to `enforce` and the name of the object is available, the configuration policy controller creates or updates the object to match in order to make the configuration policy compliant.
           properties:
             apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              description: >-
+                APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              description: >-
+                Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
             spec:
-              description: |-
-                ConfigurationPolicySpec defines the desired configuration of objects on the cluster, along with
-                how the controller should handle when the cluster doesn't match the configuration policy.
+              description: >-
+                ConfigurationPolicySpec defines the desired configuration of objects on the cluster, along with how the controller should handle when the cluster doesn't match the configuration policy.
               oneOf:
                 - required:
                     - object-templates
@@ -449,33 +374,23 @@ spec:
                     - object-templates-raw
               properties:
                 evaluationInterval:
-                  description: |-
-                    EvaluationInterval configures the minimum elapsed time before a configuration policy is
-                    reevaluated. The default value is `watch` to leverage Kubernetes API watches instead of polling the Kubernetes API
-                    server. If the policy spec is changed or if the list of namespaces selected by the policy changes, the policy might
-                    be evaluated regardless of the settings here.
+                  description: >-
+                    EvaluationInterval configures the minimum elapsed time before a configuration policy is reevaluated. The default value is `watch` to leverage Kubernetes API watches instead of polling the Kubernetes API server. If the policy spec is changed or if the list of namespaces selected by the policy changes, the policy might be evaluated regardless of the settings here.
                   properties:
                     compliant:
-                      description: |-
-                        Compliant is the minimum elapsed time before a configuration policy is reevaluated when in the
-                        compliant state. Set this to `never` to disable reevaluation when in the compliant state. The default value is
-                        `watch`.
+                      description: >-
+                        Compliant is the minimum elapsed time before a configuration policy is reevaluated when in the compliant state. Set this to `never` to disable reevaluation when in the compliant state. The default value is `watch`.
                       pattern: ^(?:(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))|never|watch)+$
                       type: string
                     noncompliant:
-                      description: |-
-                        NonCompliant is the minimum elapsed time before a configuration policy is reevaluated when in the noncompliant
-                        state. Set this to `never` to disable reevaluation when in the noncompliant state. The default value is `watch`.
+                      description: >-
+                        NonCompliant is the minimum elapsed time before a configuration policy is reevaluated when in the noncompliant state. Set this to `never` to disable reevaluation when in the noncompliant state. The default value is `watch`.
                       pattern: ^(?:(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))|never|watch)+$
                       type: string
                   type: object
                 namespaceSelector:
-                  description: |-
-                    NamespaceSelector defines the list of namespaces to include or exclude for objects defined in
-                    `spec["object-templates"]`. All selector rules are combined. If 'include' is not provided but
-                    `matchLabels` and/or `matchExpressions` are, `include` will behave as if `['*']` were given. If
-                    `matchExpressions` and `matchLabels` are both not provided, `include` must be provided to
-                    retrieve namespaces.
+                  description: >-
+                    NamespaceSelector defines the list of namespaces to include or exclude for objects defined in `spec["object-templates"]`. All selector rules are combined. If 'include' is not provided but `matchLabels` and/or `matchExpressions` are, `include` will behave as if `['*']` were given. If `matchExpressions` and `matchLabels` are both not provided, `include` must be provided to retrieve namespaces.
                   properties:
                     exclude:
                       description: Exclude is an array of filepath expressions to exclude objects by name.
@@ -492,24 +407,19 @@ spec:
                     matchExpressions:
                       description: MatchExpressions is an array of label selector requirements matching objects by label.
                       items:
-                        description: |-
-                          A label selector requirement is a selector that contains values, a key, and an operator that
-                          relates the key and values.
+                        description: >-
+                          A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                         properties:
                           key:
                             description: key is the label key that the selector applies to.
                             type: string
                           operator:
-                            description: |-
-                              operator represents a key's relationship to a set of values.
-                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: >-
+                              operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: |-
-                              values is an array of string values. If the operator is In or NotIn,
-                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                              the values array must be empty. This array is replaced during a strategic
-                              merge patch.
+                            description: >-
+                              values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                             items:
                               type: string
                             type: array
@@ -525,21 +435,14 @@ spec:
                       type: object
                   type: object
                 object-templates:
-                  description: |-
-                    The `object-templates` is an array of object configurations for the configuration policy to
-                    check, create, modify, or delete objects on the cluster. Keys inside of the objectDefinition in
-                    an object template may point to values that have Go templates. For more advanced Go templating
-                    such as `range` loops and `if` conditionals, use `object-templates-raw`. Only one of
-                    `object-templates` and `object-templates-raw` can be set in a configuration policy. For more on
-                    the Go templates, see https://github.com/stolostron/go-template-utils/blob/main/README.md.
+                  description: >-
+                    The `object-templates` is an array of object configurations for the configuration policy to check, create, modify, or delete objects on the cluster. Keys inside of the objectDefinition in an object template may point to values that have Go templates. For more advanced Go templating such as `range` loops and `if` conditionals, use `object-templates-raw`. Only one of `object-templates` and `object-templates-raw` can be set in a configuration policy. For more on the Go templates, see https://github.com/stolostron/go-template-utils/blob/main/README.md.
                   items:
                     description: ObjectTemplate describes the desired state of an object on the cluster.
                     properties:
                       complianceType:
-                        description: |-
-                          ComplianceType describes how objects on the cluster should be compared with the object definition
-                          of the configuration policy. The supported options are `MustHave`, `MustOnlyHave`, or
-                          `MustNotHave`.
+                        description: >-
+                          ComplianceType describes how objects on the cluster should be compared with the object definition of the configuration policy. The supported options are `MustHave`, `MustOnlyHave`, or `MustNotHave`.
                         enum:
                           - MustHave
                           - Musthave
@@ -552,11 +455,8 @@ spec:
                           - mustnothave
                         type: string
                       metadataComplianceType:
-                        description: |-
-                          MetadataComplianceType describes how the labels and annotations of objects on the cluster should
-                          be compared with the object definition of the configuration policy. The supported options are
-                          `MustHave` or `MustOnlyHave`. The default value is the value defined in `complianceType` for the
-                          object template.
+                        description: >-
+                          MetadataComplianceType describes how the labels and annotations of objects on the cluster should be compared with the object definition of the configuration policy. The supported options are `MustHave` or `MustOnlyHave`. The default value is the value defined in `complianceType` for the object template.
                         enum:
                           - MustHave
                           - Musthave
@@ -570,14 +470,8 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       recordDiff:
-                        description: |-
-                          RecordDiff specifies whether and where to log the difference between the object on the cluster
-                          and the `objectDefinition` parameter in the policy. The supported options are `InStatus` to
-                          record the difference in the policy status field, `Log` to log the difference in the
-                          `config-policy-controller` pod, and `None` to not log the difference. The default value is
-                          `None` for object kinds that include sensitive data such as `ConfigMap`, `OAuthAccessToken`,
-                          `OAuthAuthorizeTokens`, `Route`, and `Secret`, or when a templated `objectDefinition`
-                          references sensitive data. For all other kinds, the default value is `InStatus`.
+                        description: >-
+                          RecordDiff specifies whether and where to log the difference between the object on the cluster and the `objectDefinition` parameter in the policy. The supported options are `InStatus` to record the difference in the policy status field, `Log` to log the difference in the `config-policy-controller` pod, and `None` to not log the difference. The default value is `None` for object kinds that include sensitive data such as `ConfigMap`, `OAuthAccessToken`, `OAuthAuthorizeTokens`, `Route`, and `Secret`, or when a templated `objectDefinition` references sensitive data. For all other kinds, the default value is `InStatus`.
                         enum:
                           - Log
                           - InStatus
@@ -585,12 +479,8 @@ spec:
                         type: string
                       recreateOption:
                         default: None
-                        description: |-
-                          RecreateOption describes when to delete and recreate an object when an update is required. When you set the
-                          object to `IfRequired`, the policy recreates the object when updating an immutable field. When you set the
-                          parameter to `Always`, the policy recreates the object on any update. When you set the `remediationAction` to
-                          `inform`, the parameter value, `recreateOption`, has no effect on the object. The `IfRequired` value has no
-                          effect on clusters without dry-run update support. The default value is `None`.
+                        description: >-
+                          RecreateOption describes when to delete and recreate an object when an update is required. When you set the object to `IfRequired`, the policy recreates the object when updating an immutable field. When you set the parameter to `Always`, the policy recreates the object on any update. When you set the `remediationAction` to `inform`, the parameter value, `recreateOption`, has no effect on the object. The `IfRequired` value has no effect on clusters without dry-run update support. The default value is `None`.
                         enum:
                           - None
                           - IfRequired
@@ -602,27 +492,21 @@ spec:
                     type: object
                   type: array
                 object-templates-raw:
-                  description: |-
-                    The `object-templates-raw` is a string containing Go templates that must ultimately produce an
-                    array of object configurations in YAML format to be used as `object-templates`. Only one of
-                    `object-templates` and `object-templates-raw` can be set in a configuration policy. For more on
-                    the Go templates, see https://github.com/stolostron/go-template-utils/blob/main/README.md.
+                  description: >-
+                    The `object-templates-raw` is a string containing Go templates that must ultimately produce an array of object configurations in YAML format to be used as `object-templates`. Only one of `object-templates` and `object-templates-raw` can be set in a configuration policy. For more on the Go templates, see https://github.com/stolostron/go-template-utils/blob/main/README.md.
                   type: string
                 pruneObjectBehavior:
                   default: None
-                  description: |-
-                    PruneObjectBehavior is used to remove objects that are managed by the policy upon either case: a
-                    change to the policy that causes an object to no longer be managed by the policy, or the deletion
-                    of the policy.
+                  description: >-
+                    PruneObjectBehavior is used to remove objects that are managed by the policy upon either case: a change to the policy that causes an object to no longer be managed by the policy, or the deletion of the policy.
                   enum:
                     - DeleteAll
                     - DeleteIfCreated
                     - None
                   type: string
                 remediationAction:
-                  description: |-
-                    RemediationAction is the remediation of the policy. The parameter values are `enforce` and
-                    `inform`.
+                  description: >-
+                    RemediationAction is the remediation of the policy. The parameter values are `enforce` and `inform`.
                   enum:
                     - Inform
                     - inform
@@ -630,9 +514,8 @@ spec:
                     - enforce
                   type: string
                 severity:
-                  description: |-
-                    Severity is a user-defined severity for when an object is noncompliant with this configuration
-                    policy. The supported options are `low`, `medium`, `high`, and `critical`.
+                  description: >-
+                    Severity is a user-defined severity for when an object is noncompliant with this configuration policy. The supported options are `low`, `medium`, `high`, and `critical`.
                   enum:
                     - low
                     - Low
@@ -647,14 +530,12 @@ spec:
                 - remediationAction
               type: object
             status:
-              description: |-
-                ConfigurationPolicyStatus is the observed status of the configuration policy from its object
-                definitions.
+              description: >-
+                ConfigurationPolicyStatus is the observed status of the configuration policy from its object definitions.
               properties:
                 compliancyDetails:
-                  description: |-
-                    CompliancyDetails is a list of statuses matching one-to-one with each of the items in the
-                    `object-templates` array.
+                  description: >-
+                    CompliancyDetails is a list of statuses matching one-to-one with each of the items in the `object-templates` array.
                   items:
                     description: TemplateStatus reports the compliance details from the definitions in an `object-template`.
                     properties:
@@ -713,15 +594,13 @@ spec:
                   description: LastEvaluated is an ISO-8601 timestamp of the last time the policy was evaluated.
                   type: string
                 lastEvaluatedGeneration:
-                  description: |-
-                    LastEvaluatedGeneration is the generation of the ConfigurationPolicy object when it was last
-                    evaluated.
+                  description: >-
+                    LastEvaluatedGeneration is the generation of the ConfigurationPolicy object when it was last evaluated.
                   format: int64
                   type: integer
                 relatedObjects:
-                  description: |-
-                    RelatedObjects is a list of objects processed by the configuration policy due to its
-                    `object-templates`.
+                  description: >-
+                    RelatedObjects is a list of objects processed by the configuration policy due to its `object-templates`.
                   items:
                     description: RelatedObject contains the details of an object matched by the policy.
                     properties:
@@ -752,19 +631,16 @@ spec:
                         description: Properties are additional properties of the related object relevant to the configuration policy.
                         properties:
                           createdByPolicy:
-                            description: |-
-                              CreatedByPolicy reports whether the object was created by the configuration policy, which is
-                              important when pruning is configured.
+                            description: >-
+                              CreatedByPolicy reports whether the object was created by the configuration policy, which is important when pruning is configured.
                             type: boolean
                           diff:
-                            description: |-
-                              Diff stores the difference between the `objectDefinition` in the policy and the object on the
-                              cluster.
+                            description: >-
+                              Diff stores the difference between the `objectDefinition` in the policy and the object on the cluster.
                             type: string
                           uid:
-                            description: |-
-                              UID stores the object UID to help track object ownership for deletion when pruning is
-                              configured.
+                            description: >-
+                              UID stores the object UID to help track object ownership for deletion when pruning is configured.
                             type: string
                         type: object
                       reason:

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_operatorpolicies_crd.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_operatorpolicies_crd.yaml
@@ -23,25 +23,16 @@ spec:
     - name: v1beta1
       schema:
         openAPIV3Schema:
-          description: |-
-            OperatorPolicy is the schema for the operatorpolicies API. You can use the operator policy to
-            manage operators by providing automation for their management and reporting on the status across
-            the various operator objects.
+          description: >-
+            OperatorPolicy is the schema for the operatorpolicies API. You can use the operator policy to manage operators by providing automation for their management and reporting on the status across the various operator objects.
           properties:
             apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              description: >-
+                APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              description: >-
+                Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -50,59 +41,49 @@ spec:
               properties:
                 complianceConfig:
                   default: {}
-                  description: |-
-                    ComplianceConfig defines how resource statuses affect the OperatorPolicy status and compliance.
-                    When set to Compliant, the condition does not impact the OperatorPolicy compliance. When set to
-                    NonCompliant, the condition causes the OperatorPolicy to become NonCompliant.
+                  description: >-
+                    ComplianceConfig defines how resource statuses affect the OperatorPolicy status and compliance. When set to Compliant, the condition does not impact the OperatorPolicy compliance. When set to NonCompliant, the condition causes the OperatorPolicy to become NonCompliant.
                   properties:
                     catalogSourceUnhealthy:
                       default: Compliant
-                      description: |-
-                        CatalogSourceUnhealthy specifies how the CatalogSourceUnhealthy typed condition should affect
-                        overall policy compliance. The default value is `Compliant`.
+                      description: >-
+                        CatalogSourceUnhealthy specifies how the CatalogSourceUnhealthy typed condition should affect overall policy compliance. The default value is `Compliant`.
                       enum:
                         - Compliant
                         - NonCompliant
                       type: string
                     deploymentsUnavailable:
                       default: NonCompliant
-                      description: |-
-                        DeploymentsUnavailable specifies how the DeploymentCompliant typed condition should affect
-                        overall policy compliance. The default value is `NonCompliant`.
+                      description: >-
+                        DeploymentsUnavailable specifies how the DeploymentCompliant typed condition should affect overall policy compliance. The default value is `NonCompliant`.
                       enum:
                         - Compliant
                         - NonCompliant
                       type: string
                     upgradesAvailable:
                       default: Compliant
-                      description: |-
-                        UpgradesAvailable specifies how the InstallPlanCompliant typed condition should affect overall
-                        policy compliance. The default value is `Compliant`.
+                      description: >-
+                        UpgradesAvailable specifies how the InstallPlanCompliant typed condition should affect overall policy compliance. The default value is `Compliant`.
                       enum:
                         - Compliant
                         - NonCompliant
                       type: string
                   type: object
                 complianceType:
-                  description: |-
-                    ComplianceType describes how objects on the cluster should be compared with the object definition
-                    of the configuration policy. The supported options are `MustHave`, `MustOnlyHave`, or
-                    `MustNotHave`.
+                  description: >-
+                    ComplianceType describes how objects on the cluster should be compared with the object definition of the configuration policy. The supported options are `MustHave`, `MustOnlyHave`, or `MustNotHave`.
                   enum:
                     - musthave
                     - mustnothave
                   type: string
                 operatorGroup:
-                  description: |-
-                    OperatorGroup specifies which `OperatorGroup` to inspect. Include the name, namespace, and any
-                    `spec` fields for the operator group. For more info, see `kubectl explain operatorgroups.spec`
-                    or view https://olm.operatorframework.io/docs/concepts/crds/operatorgroup/.
+                  description: >-
+                    OperatorGroup specifies which `OperatorGroup` to inspect. Include the name, namespace, and any `spec` fields for the operator group. For more info, see `kubectl explain operatorgroups.spec` or view https://olm.operatorframework.io/docs/concepts/crds/operatorgroup/.
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 remediationAction:
-                  description: |-
-                    RemediationAction is the remediation of the policy. The parameter values are `enforce` and
-                    `inform`.
+                  description: >-
+                    RemediationAction is the remediation of the policy. The parameter values are `enforce` and `inform`.
                   enum:
                     - Inform
                     - inform
@@ -111,10 +92,8 @@ spec:
                   type: string
                 removalBehavior:
                   default: {}
-                  description: |-
-                    Use RemovalBehavior to define what resources need to be removed when enforcing `mustnothave`
-                    policies. When in `inform` mode, any resources that are deleted if the policy is set to
-                    `enforce` makes the policy noncompliant, but resources that are kept are compliant.
+                  description: >-
+                    Use RemovalBehavior to define what resources need to be removed when enforcing `mustnothave` policies. When in `inform` mode, any resources that are deleted if the policy is set to `enforce` makes the policy noncompliant, but resources that are kept are compliant.
                   properties:
                     clusterServiceVersions:
                       allOf:
@@ -126,9 +105,8 @@ spec:
                             - Keep
                             - Delete
                       default: Delete
-                      description: |-
-                        Use the `clusterServiceVersions` parameter to specify whether to delete the
-                        ClusterServiceVersion. The default value is `Delete`.
+                      description: >-
+                        Use the `clusterServiceVersions` parameter to specify whether to delete the ClusterServiceVersion. The default value is `Delete`.
                       type: string
                     customResourceDefinitions:
                       allOf:
@@ -140,10 +118,8 @@ spec:
                             - Keep
                             - Delete
                       default: Keep
-                      description: |-
-                        Use the customResourceDefinitions parameter to specify whether to delete any
-                        CustomResourceDefinitions associated with the operator. The default value is `Keep`, because
-                        deleting them should be done deliberately.
+                      description: >-
+                        Use the customResourceDefinitions parameter to specify whether to delete any CustomResourceDefinitions associated with the operator. The default value is `Keep`, because deleting them should be done deliberately.
                       type: string
                     operatorGroups:
                       allOf:
@@ -155,10 +131,8 @@ spec:
                             - Keep
                             - DeleteIfUnused
                       default: DeleteIfUnused
-                      description: |-
-                        Use the `operatorGroups` parameter to specify whether to delete the OperatorGroup. The default
-                        value is `DeleteIfUnused`, which only deletes the OperatorGroup if there is not another
-                        resource using it.
+                      description: >-
+                        Use the `operatorGroups` parameter to specify whether to delete the OperatorGroup. The default value is `DeleteIfUnused`, which only deletes the OperatorGroup if there is not another resource using it.
                       type: string
                     subscriptions:
                       allOf:
@@ -170,15 +144,13 @@ spec:
                             - Keep
                             - Delete
                       default: Delete
-                      description: |-
-                        Use the `subscriptions` parameter to specify whether to delete the Subscription. The default
-                        value is `Delete`.
+                      description: >-
+                        Use the `subscriptions` parameter to specify whether to delete the Subscription. The default value is `Delete`.
                       type: string
                   type: object
                 severity:
-                  description: |-
-                    Severity is a user-defined severity for when an object is noncompliant with this configuration
-                    policy. The supported options are `low`, `medium`, `high`, and `critical`.
+                  description: >-
+                    Severity is a user-defined severity for when an object is noncompliant with this configuration policy. The supported options are `low`, `medium`, `high`, and `critical`.
                   enum:
                     - low
                     - Low
@@ -190,27 +162,20 @@ spec:
                     - Critical
                   type: string
                 subscription:
-                  description: |-
-                    Subscription specifies which operator `Subscription` resource to inspect. Include the
-                    namespace, and any `spec` fields for the Subscription. For more info, see `kubectl explain
-                    subscriptions.operators.coreos.com.spec` or view
-                    https://olm.operatorframework.io/docs/concepts/crds/subscription/.
+                  description: >-
+                    Subscription specifies which operator `Subscription` resource to inspect. Include the namespace, and any `spec` fields for the Subscription. For more info, see `kubectl explain subscriptions.operators.coreos.com.spec` or view https://olm.operatorframework.io/docs/concepts/crds/subscription/.
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 upgradeApproval:
-                  description: |-
-                    UpgradeApproval determines whether 'upgrade' InstallPlans for the operator will be approved
-                    by the controller when the policy is enforced and in 'musthave' mode. The initial InstallPlan
-                    approval is not affected by this setting. This setting has no effect when the policy is in
-                    'mustnothave' mode. Allowed values are "None" or "Automatic".
+                  description: >-
+                    UpgradeApproval determines whether 'upgrade' InstallPlans for the operator will be approved by the controller when the policy is enforced and in 'musthave' mode. The initial InstallPlan approval is not affected by this setting. This setting has no effect when the policy is in 'mustnothave' mode. Allowed values are "None" or "Automatic".
                   enum:
                     - None
                     - Automatic
                   type: string
                 versions:
-                  description: |-
-                    Versions is a list of non-empty strings that specifies which installed versions are compliant
-                    when in `inform` mode and which `InstallPlans` are approved when in `enforce` mode.
+                  description: >-
+                    Versions is a list of non-empty strings that specifies which installed versions are compliant when in `inform` mode and which `InstallPlans` are approved when in `enforce` mode.
                   items:
                     minLength: 1
                     type: string
@@ -221,9 +186,8 @@ spec:
                 - upgradeApproval
               type: object
             status:
-              description: |-
-                OperatorPolicyStatus is the observed state of the operators from the specifications given in the
-                operator policy.
+              description: >-
+                OperatorPolicyStatus is the observed state of the operators from the specifications given in the operator policy.
               properties:
                 compliant:
                   description: ComplianceState reports the most recent compliance state of the operator policy.
@@ -239,32 +203,24 @@ spec:
                     description: "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}"
                     properties:
                       lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        description: >-
+                          lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                         format: date-time
                         type: string
                       message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
+                        description: >-
+                          message is a human readable message indicating details about the transition. This may be an empty string.
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
+                        description: >-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
                       reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
+                        description: >-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
                         maxLength: 1024
                         minLength: 1
                         pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -277,12 +233,8 @@ spec:
                           - Unknown
                         type: string
                       type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        description: >-
+                          type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
@@ -298,9 +250,8 @@ spec:
                     - type
                   x-kubernetes-list-type: map
                 overlappingPolicies:
-                  description: |-
-                    The list of overlapping OperatorPolicies (as name.namespace) which all manage the same
-                    subscription, including this policy. When no overlapping is detected, this list will be empty.
+                  description: >-
+                    The list of overlapping OperatorPolicies (as name.namespace) which all manage the same subscription, including this policy. When no overlapping is detected, this list will be empty.
                   items:
                     type: string
                   type: array
@@ -336,14 +287,12 @@ spec:
                         description: Properties are additional properties of the related object relevant to the configuration policy.
                         properties:
                           createdByPolicy:
-                            description: |-
-                              CreatedByPolicy reports whether the object was created by the configuration policy, which is
-                              important when pruning is configured.
+                            description: >-
+                              CreatedByPolicy reports whether the object was created by the configuration policy, which is important when pruning is configured.
                             type: boolean
                           uid:
-                            description: |-
-                              UID stores the object UID to help track object ownership for deletion when pruning is
-                              configured.
+                            description: >-
+                              UID stores the object UID to help track object ownership for deletion when pruning is configured.
                             type: string
                         type: object
                       reason:
@@ -355,11 +304,8 @@ spec:
                   description: The resolved name.namespace of the subscription
                   type: string
                 subscriptionInterventionTime:
-                  description: |-
-                    Timestamp for a possible intervention to help a Subscription stuck with a
-                    ConstraintsNotSatisfiable condition. Can be in the future, indicating the
-                    policy is waiting for OLM to resolve the situation. If in the recent past,
-                    the policy may update the status of the Subscription.
+                  description: >-
+                    Timestamp for a possible intervention to help a Subscription stuck with a ConstraintsNotSatisfiable condition. Can be in the future, indicating the policy is waiting for OLM to resolve the situation. If in the recent past, the policy may update the status of the Subscription.
                   format: date-time
                   type: string
               type: object

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
@@ -35,75 +35,49 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: |-
-        Policy is the schema for the policies API. Policy wraps other policy engine resources in its
-        "policy-templates" array in order to deliver the resources to managed clusters.
+      description: >-
+        Policy is the schema for the policies API. Policy wraps other policy engine resources in its "policy-templates" array in order to deliver the resources to managed clusters.
       properties:
         apiVersion:
-          description: |-
-            APIVersion defines the versioned schema of this representation of an object.
-            Servers should convert recognized schemas to the latest internal value, and
-            may reject unrecognized values.
-            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+          description: >-
+            APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
           type: string
         kind:
-          description: |-
-            Kind is a string value representing the REST resource this object represents.
-            Servers may infer this from the endpoint the client submits requests to.
-            Cannot be updated.
-            In CamelCase.
-            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+          description: >-
+            Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
           type: string
         metadata:
           type: object
         spec:
-          description: |-
-            PolicySpec defines the configurations of the policy engine resources to deliver to the managed
-            clusters.
+          description: >-
+            PolicySpec defines the configurations of the policy engine resources to deliver to the managed clusters.
           properties:
             copyPolicyMetadata:
-              description: |-
-                CopyPolicyMetadata specifies whether the labels and annotations of a policy should be copied
-                when replicating the policy to a managed cluster. If set to "true", all of the labels and
-                annotations of the policy are copied to the replicated policy. If set to "false", only the
-                policy framework-specific policy labels and annotations are copied to the replicated policy.
-                This setting is useful if there is tracking for metadata that should only exist on the root
-                policy. It is recommended to set this to "false" when using Argo CD to deploy the policy
-                definition since Argo CD uses metadata for tracking that should not be replicated. The default
-                value is "true".
+              description: >-
+                CopyPolicyMetadata specifies whether the labels and annotations of a policy should be copied when replicating the policy to a managed cluster. If set to "true", all of the labels and annotations of the policy are copied to the replicated policy. If set to "false", only the policy framework-specific policy labels and annotations are copied to the replicated policy. This setting is useful if there is tracking for metadata that should only exist on the root policy. It is recommended to set this to "false" when using Argo CD to deploy the policy definition since Argo CD uses metadata for tracking that should not be replicated. The default value is "true".
               type: boolean
             dependencies:
-              description: |-
-                PolicyDependencies is a list of dependency objects detailed with extra considerations for
-                compliance that should be fulfilled before applying the policies to the managed clusters.
+              description: >-
+                PolicyDependencies is a list of dependency objects detailed with extra considerations for compliance that should be fulfilled before applying the policies to the managed clusters.
               items:
-                description: |-
-                  Each PolicyDependency defines an object reference which must be in a certain compliance
-                  state before the policy should be created.
+                description: >-
+                  Each PolicyDependency defines an object reference which must be in a certain compliance state before the policy should be created.
                 properties:
                   apiVersion:
-                    description: |-
-                      APIVersion defines the versioned schema of this representation of an object.
-                      Servers should convert recognized schemas to the latest internal value, and
-                      may reject unrecognized values.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    description: >-
+                      APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                     type: string
                   compliance:
-                    description: |-
-                      Compliance is the required ComplianceState of the object that the policy depends on, at the
-                      following path, .status.compliant.
+                    description: >-
+                      Compliance is the required ComplianceState of the object that the policy depends on, at the following path, .status.compliant.
                     enum:
                       - Compliant
                       - Pending
                       - NonCompliant
                     type: string
                   kind:
-                    description: |-
-                      Kind is a string value representing the REST resource this object represents.
-                      Servers may infer this from the endpoint the client submits requests to.
-                      Cannot be updated.
-                      In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    description: >-
+                      Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                     type: string
                   name:
                     description: Name is the name of the object that the policy depends on.
@@ -117,53 +91,38 @@ spec:
                 type: object
               type: array
             disabled:
-              description: |-
-                Disabled is a boolean parameter you can use to enable and disable the policy. When disabled,
-                the policy is removed from managed clusters.
+              description: >-
+                Disabled is a boolean parameter you can use to enable and disable the policy. When disabled, the policy is removed from managed clusters.
               type: boolean
             policy-templates:
-              description: |-
-                PolicyTemplates is a list of definitions of policy engine resources to apply to managed
-                clusters along with configurations on how it should be applied.
+              description: >-
+                PolicyTemplates is a list of definitions of policy engine resources to apply to managed clusters along with configurations on how it should be applied.
               items:
-                description: |-
-                  PolicyTemplate is the definition of the policy engine resource to apply to the managed cluster,
-                  along with configurations on how it should be applied.
+                description: >-
+                  PolicyTemplate is the definition of the policy engine resource to apply to the managed cluster, along with configurations on how it should be applied.
                 properties:
                   extraDependencies:
-                    description: |-
-                      ExtraDependencies is additional PolicyDependencies that only apply to this policy template.
-                      ExtraDependencies is a list of dependency objects detailed with extra considerations for
-                      compliance that should be fulfilled before applying the policy template to the managed
-                      clusters.
+                    description: >-
+                      ExtraDependencies is additional PolicyDependencies that only apply to this policy template. ExtraDependencies is a list of dependency objects detailed with extra considerations for compliance that should be fulfilled before applying the policy template to the managed clusters.
                     items:
-                      description: |-
-                        Each PolicyDependency defines an object reference which must be in a certain compliance
-                        state before the policy should be created.
+                      description: >-
+                        Each PolicyDependency defines an object reference which must be in a certain compliance state before the policy should be created.
                       properties:
                         apiVersion:
-                          description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                          description: >-
+                            APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                           type: string
                         compliance:
-                          description: |-
-                            Compliance is the required ComplianceState of the object that the policy depends on, at the
-                            following path, .status.compliant.
+                          description: >-
+                            Compliance is the required ComplianceState of the object that the policy depends on, at the following path, .status.compliant.
                           enum:
                             - Compliant
                             - Pending
                             - NonCompliant
                           type: string
                         kind:
-                          description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                          description: >-
+                            Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                           type: string
                         name:
                           description: Name is the name of the object that the policy depends on.
@@ -177,10 +136,8 @@ spec:
                       type: object
                     type: array
                   ignorePending:
-                    description: |-
-                      IgnorePending is a boolean parameter to specify whether to ignore the "Pending" status of this
-                      template when calculating the overall policy status. The default value is "false" to not ignore a
-                      "Pending" status.
+                    description: >-
+                      IgnorePending is a boolean parameter to specify whether to ignore the "Pending" status of this template when calculating the overall policy status. The default value is "false" to not ignore a "Pending" status.
                     type: boolean
                   objectDefinition:
                     description: A Kubernetes object defining the policy to apply to a managed cluster
@@ -191,11 +148,8 @@ spec:
                 type: object
               type: array
             remediationAction:
-              description: |-
-                RemediationAction specifies the remediation of the policy. The parameter values are "enforce"
-                and "inform". If specified, the value that is defined overrides any remediationAction parameter
-                defined in the child policies in the "policy-templates" section. Important: Not all policy
-                engine kinds support the enforce feature.
+              description: >-
+                RemediationAction specifies the remediation of the policy. The parameter values are "enforce" and "inform". If specified, the value that is defined overrides any remediationAction parameter defined in the child policies in the "policy-templates" section. Important: Not all policy engine kinds support the enforce feature.
               enum:
                 - Inform
                 - inform
@@ -210,22 +164,19 @@ spec:
           description: PolicyStatus reports the observed status of the policy resulting from its policy templates.
           properties:
             compliant:
-              description: |-
-                ComplianceState reports the observed status resulting from the definitions of this policy. This
-                status field is only used in the replicated policy in the managed cluster namespace.
+              description: >-
+                ComplianceState reports the observed status resulting from the definitions of this policy. This status field is only used in the replicated policy in the managed cluster namespace.
               enum:
                 - Compliant
                 - Pending
                 - NonCompliant
               type: string
             details:
-              description: |-
-                Details is the list of compliance details for each policy template definition. This status
-                field is only used in the replicated policy in the managed cluster namespace.
+              description: >-
+                Details is the list of compliance details for each policy template definition. This status field is only used in the replicated policy in the managed cluster namespace.
               items:
-                description: |-
-                  DetailsPerTemplate reports the current compliance state and list of recent compliance messages
-                  for a given policy template.
+                description: >-
+                  DetailsPerTemplate reports the current compliance state and list of recent compliance messages for a given policy template.
                 properties:
                   compliant:
                     description: ComplianceState reports the observed status resulting from the definitions of the policy.
@@ -256,9 +207,8 @@ spec:
                 type: object
               type: array
             placement:
-              description: |-
-                Placement is a list of managed cluster placement resources bound to the policy. This status
-                field is only used in the root policy on the hub cluster.
+              description: >-
+                Placement is a list of managed cluster placement resources bound to the policy. This status field is only used in the root policy on the hub cluster.
               items:
                 description: Placement reports how and what managed cluster placement resources are attached to the policy.
                 properties:
@@ -274,36 +224,29 @@ spec:
                       type: object
                     type: array
                   placement:
-                    description: |-
-                      Placement is the name of the Placement resource, from the cluster.open-cluster-management.io
-                      API group, that is bound to the policy.
+                    description: >-
+                      Placement is the name of the Placement resource, from the cluster.open-cluster-management.io API group, that is bound to the policy.
                     type: string
                   placementBinding:
-                    description: |-
-                      PlacementBinding is the name of the PlacementBinding resource, from the
-                      policies.open-cluster-management.io API group, that binds the placement resource to the policy.
+                    description: >-
+                      PlacementBinding is the name of the PlacementBinding resource, from the policies.open-cluster-management.io API group, that binds the placement resource to the policy.
                     type: string
                   placementRule:
-                    description: |-
-                      PlacementRule (deprecated) is the name of the PlacementRule resource, from the
-                      apps.open-cluster-management.io API group, that is bound to the policy.
+                    description: >-
+                      PlacementRule (deprecated) is the name of the PlacementRule resource, from the apps.open-cluster-management.io API group, that is bound to the policy.
                     type: string
                   policySet:
-                    description: |-
-                      PolicySet is the name of the policy set containing this policy and bound to the placement. If
-                      specified, then for this placement the policy is being propagated through this policy set
-                      rather than the policy being bound directly to a placement and propagated individually.
+                    description: >-
+                      PolicySet is the name of the policy set containing this policy and bound to the placement. If specified, then for this placement the policy is being propagated through this policy set rather than the policy being bound directly to a placement and propagated individually.
                     type: string
                 type: object
               type: array
             status:
-              description: |-
-                Status is a list of managed clusters and the current compliance state of each one. This
-                status field is only used in the root policy on the hub cluster.
+              description: >-
+                Status is a list of managed clusters and the current compliance state of each one. This status field is only used in the root policy on the hub cluster.
               items:
-                description: |-
-                  CompliancePerClusterStatus reports the name of a managed cluster and its compliance state for
-                  this policy.
+                description: >-
+                  CompliancePerClusterStatus reports the name of a managed cluster and its compliance state for this policy.
                 properties:
                   clustername:
                     type: string
@@ -363,51 +306,33 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: |-
-            Policy is the schema for the policies API. Policy wraps other policy engine resources in its
-            "policy-templates" array in order to deliver the resources to managed clusters.
+          description: >-
+            Policy is the schema for the policies API. Policy wraps other policy engine resources in its "policy-templates" array in order to deliver the resources to managed clusters.
           properties:
             apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              description: >-
+                APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              description: >-
+                Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
             spec:
-              description: |-
-                PolicySpec defines the configurations of the policy engine resources to deliver to the managed
-                clusters.
+              description: >-
+                PolicySpec defines the configurations of the policy engine resources to deliver to the managed clusters.
               properties:
                 copyPolicyMetadata:
-                  description: |-
-                    CopyPolicyMetadata specifies whether the labels and annotations of a policy should be copied
-                    when replicating the policy to a managed cluster. If set to "true", all of the labels and
-                    annotations of the policy are copied to the replicated policy. If set to "false", only the
-                    policy framework-specific policy labels and annotations are copied to the replicated policy.
-                    This setting is useful if there is tracking for metadata that should only exist on the root
-                    policy. It is recommended to set this to "false" when using Argo CD to deploy the policy
-                    definition since Argo CD uses metadata for tracking that should not be replicated. The default
-                    value is "true".
+                  description: >-
+                    CopyPolicyMetadata specifies whether the labels and annotations of a policy should be copied when replicating the policy to a managed cluster. If set to "true", all of the labels and annotations of the policy are copied to the replicated policy. If set to "false", only the policy framework-specific policy labels and annotations are copied to the replicated policy. This setting is useful if there is tracking for metadata that should only exist on the root policy. It is recommended to set this to "false" when using Argo CD to deploy the policy definition since Argo CD uses metadata for tracking that should not be replicated. The default value is "true".
                   type: boolean
                 dependencies:
-                  description: |-
-                    PolicyDependencies is a list of dependency objects detailed with extra considerations for
-                    compliance that should be fulfilled before applying the policies to the managed clusters.
+                  description: >-
+                    PolicyDependencies is a list of dependency objects detailed with extra considerations for compliance that should be fulfilled before applying the policies to the managed clusters.
                   items:
-                    description: |-
-                      Each PolicyDependency defines an object reference which must be in a certain compliance
-                      state before the policy should be created.
+                    description: >-
+                      Each PolicyDependency defines an object reference which must be in a certain compliance state before the policy should be created.
                     oneOf:
                       - properties:
                           kind:
@@ -422,28 +347,20 @@ spec:
                               pattern: ^(?:(?:Certificate|Configuration)Policy)$
                     properties:
                       apiVersion:
-                        description: |-
-                          APIVersion defines the versioned schema of this representation of an object.
-                          Servers should convert recognized schemas to the latest internal value, and
-                          may reject unrecognized values.
-                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        description: >-
+                          APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                         type: string
                       compliance:
-                        description: |-
-                          Compliance is the required ComplianceState of the object that the policy depends on, at the
-                          following path, .status.compliant.
+                        description: >-
+                          Compliance is the required ComplianceState of the object that the policy depends on, at the following path, .status.compliant.
                         enum:
                           - Compliant
                           - Pending
                           - NonCompliant
                         type: string
                       kind:
-                        description: |-
-                          Kind is a string value representing the REST resource this object represents.
-                          Servers may infer this from the endpoint the client submits requests to.
-                          Cannot be updated.
-                          In CamelCase.
-                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        description: >-
+                          Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                         type: string
                       name:
                         description: Name is the name of the object that the policy depends on.
@@ -457,29 +374,22 @@ spec:
                     type: object
                   type: array
                 disabled:
-                  description: |-
-                    Disabled is a boolean parameter you can use to enable and disable the policy. When disabled,
-                    the policy is removed from managed clusters.
+                  description: >-
+                    Disabled is a boolean parameter you can use to enable and disable the policy. When disabled, the policy is removed from managed clusters.
                   type: boolean
                 policy-templates:
-                  description: |-
-                    PolicyTemplates is a list of definitions of policy engine resources to apply to managed
-                    clusters along with configurations on how it should be applied.
+                  description: >-
+                    PolicyTemplates is a list of definitions of policy engine resources to apply to managed clusters along with configurations on how it should be applied.
                   items:
-                    description: |-
-                      PolicyTemplate is the definition of the policy engine resource to apply to the managed cluster,
-                      along with configurations on how it should be applied.
+                    description: >-
+                      PolicyTemplate is the definition of the policy engine resource to apply to the managed cluster, along with configurations on how it should be applied.
                     properties:
                       extraDependencies:
-                        description: |-
-                          ExtraDependencies is additional PolicyDependencies that only apply to this policy template.
-                          ExtraDependencies is a list of dependency objects detailed with extra considerations for
-                          compliance that should be fulfilled before applying the policy template to the managed
-                          clusters.
+                        description: >-
+                          ExtraDependencies is additional PolicyDependencies that only apply to this policy template. ExtraDependencies is a list of dependency objects detailed with extra considerations for compliance that should be fulfilled before applying the policy template to the managed clusters.
                         items:
-                          description: |-
-                            Each PolicyDependency defines an object reference which must be in a certain compliance
-                            state before the policy should be created.
+                          description: >-
+                            Each PolicyDependency defines an object reference which must be in a certain compliance state before the policy should be created.
                           oneOf:
                             - properties:
                                 kind:
@@ -494,28 +404,20 @@ spec:
                                     pattern: ^(?:(?:Certificate|Configuration)Policy)$
                           properties:
                             apiVersion:
-                              description: |-
-                                APIVersion defines the versioned schema of this representation of an object.
-                                Servers should convert recognized schemas to the latest internal value, and
-                                may reject unrecognized values.
-                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                              description: >-
+                                APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                               type: string
                             compliance:
-                              description: |-
-                                Compliance is the required ComplianceState of the object that the policy depends on, at the
-                                following path, .status.compliant.
+                              description: >-
+                                Compliance is the required ComplianceState of the object that the policy depends on, at the following path, .status.compliant.
                               enum:
                                 - Compliant
                                 - Pending
                                 - NonCompliant
                               type: string
                             kind:
-                              description: |-
-                                Kind is a string value representing the REST resource this object represents.
-                                Servers may infer this from the endpoint the client submits requests to.
-                                Cannot be updated.
-                                In CamelCase.
-                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                              description: >-
+                                Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                               type: string
                             name:
                               description: Name is the name of the object that the policy depends on.
@@ -529,10 +431,8 @@ spec:
                           type: object
                         type: array
                       ignorePending:
-                        description: |-
-                          IgnorePending is a boolean parameter to specify whether to ignore the "Pending" status of this
-                          template when calculating the overall policy status. The default value is "false" to not ignore a
-                          "Pending" status.
+                        description: >-
+                          IgnorePending is a boolean parameter to specify whether to ignore the "Pending" status of this template when calculating the overall policy status. The default value is "false" to not ignore a "Pending" status.
                         type: boolean
                       objectDefinition:
                         description: A Kubernetes object defining the policy to apply to a managed cluster
@@ -543,11 +443,8 @@ spec:
                     type: object
                   type: array
                 remediationAction:
-                  description: |-
-                    RemediationAction specifies the remediation of the policy. The parameter values are "enforce"
-                    and "inform". If specified, the value that is defined overrides any remediationAction parameter
-                    defined in the child policies in the "policy-templates" section. Important: Not all policy
-                    engine kinds support the enforce feature.
+                  description: >-
+                    RemediationAction specifies the remediation of the policy. The parameter values are "enforce" and "inform". If specified, the value that is defined overrides any remediationAction parameter defined in the child policies in the "policy-templates" section. Important: Not all policy engine kinds support the enforce feature.
                   enum:
                     - Inform
                     - inform
@@ -562,22 +459,19 @@ spec:
               description: PolicyStatus reports the observed status of the policy resulting from its policy templates.
               properties:
                 compliant:
-                  description: |-
-                    ComplianceState reports the observed status resulting from the definitions of this policy. This
-                    status field is only used in the replicated policy in the managed cluster namespace.
+                  description: >-
+                    ComplianceState reports the observed status resulting from the definitions of this policy. This status field is only used in the replicated policy in the managed cluster namespace.
                   enum:
                     - Compliant
                     - Pending
                     - NonCompliant
                   type: string
                 details:
-                  description: |-
-                    Details is the list of compliance details for each policy template definition. This status
-                    field is only used in the replicated policy in the managed cluster namespace.
+                  description: >-
+                    Details is the list of compliance details for each policy template definition. This status field is only used in the replicated policy in the managed cluster namespace.
                   items:
-                    description: |-
-                      DetailsPerTemplate reports the current compliance state and list of recent compliance messages
-                      for a given policy template.
+                    description: >-
+                      DetailsPerTemplate reports the current compliance state and list of recent compliance messages for a given policy template.
                     properties:
                       compliant:
                         description: ComplianceState reports the observed status resulting from the definitions of the policy.
@@ -608,9 +502,8 @@ spec:
                     type: object
                   type: array
                 placement:
-                  description: |-
-                    Placement is a list of managed cluster placement resources bound to the policy. This status
-                    field is only used in the root policy on the hub cluster.
+                  description: >-
+                    Placement is a list of managed cluster placement resources bound to the policy. This status field is only used in the root policy on the hub cluster.
                   items:
                     description: Placement reports how and what managed cluster placement resources are attached to the policy.
                     properties:
@@ -626,36 +519,29 @@ spec:
                           type: object
                         type: array
                       placement:
-                        description: |-
-                          Placement is the name of the Placement resource, from the cluster.open-cluster-management.io
-                          API group, that is bound to the policy.
+                        description: >-
+                          Placement is the name of the Placement resource, from the cluster.open-cluster-management.io API group, that is bound to the policy.
                         type: string
                       placementBinding:
-                        description: |-
-                          PlacementBinding is the name of the PlacementBinding resource, from the
-                          policies.open-cluster-management.io API group, that binds the placement resource to the policy.
+                        description: >-
+                          PlacementBinding is the name of the PlacementBinding resource, from the policies.open-cluster-management.io API group, that binds the placement resource to the policy.
                         type: string
                       placementRule:
-                        description: |-
-                          PlacementRule (deprecated) is the name of the PlacementRule resource, from the
-                          apps.open-cluster-management.io API group, that is bound to the policy.
+                        description: >-
+                          PlacementRule (deprecated) is the name of the PlacementRule resource, from the apps.open-cluster-management.io API group, that is bound to the policy.
                         type: string
                       policySet:
-                        description: |-
-                          PolicySet is the name of the policy set containing this policy and bound to the placement. If
-                          specified, then for this placement the policy is being propagated through this policy set
-                          rather than the policy being bound directly to a placement and propagated individually.
+                        description: >-
+                          PolicySet is the name of the policy set containing this policy and bound to the placement. If specified, then for this placement the policy is being propagated through this policy set rather than the policy being bound directly to a placement and propagated individually.
                         type: string
                     type: object
                   type: array
                 status:
-                  description: |-
-                    Status is a list of managed clusters and the current compliance state of each one. This
-                    status field is only used in the root policy on the hub cluster.
+                  description: >-
+                    Status is a list of managed clusters and the current compliance state of each one. This status field is only used in the root policy on the hub cluster.
                   items:
-                    description: |-
-                      CompliancePerClusterStatus reports the name of a managed cluster and its compliance state for
-                      this policy.
+                    description: >-
+                      CompliancePerClusterStatus reports the name of a managed cluster and its compliance state for this policy.
                     properties:
                       clustername:
                         type: string


### PR DESCRIPTION
I worked out a super-cool script to reflow all of our CRDs to 80 characters using `yq` and the `prettier` CLI:
```bash
desc_paths=$(yq '.. | select(has("description")) | (path | join("."))' "${crd_path}")

echo "Formatting descriptions..."
for root in ${desc_paths}; do
    desc_fmt=$(yq ".${root}.description" "${crd_path}" | prettier --parser=markdown --prose-wrap=always)
    desc_fmt=${desc_fmt} yq ".${root}.description=strenv(desc_fmt)" -i "${crd_path}"
done
```
But ultimately I think `sed` is the way to go (and the simplest) until `kubectl explain` formats things properly since none of our CRDs currently attempt to use lists or formatted Markdown of any sort.