### PR TITLE
Add the ocm-policies namespace to the uninstall

### DIFF
--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cleanup_pod.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cleanup_pod.yaml
@@ -29,6 +29,7 @@ spec:
         - --policy-namespace={{ .Release.Namespace }}
         {{- else }}
         - --policy-namespace={{ .Values.clusterName }}
+        - --additional-namespace=open-cluster-management-policies
         {{- end }}
         - --v={{ .Values.args.pkgLogLevel }}
       env:


### PR DESCRIPTION
ConfigurationPolicies in that namespace should be checked for finalizers so that the uninstall can complete. It should not be checked when the addon is in hosted mode, since in that case the namespace might be used by other clusters.

Refs:
 - https://issues.redhat.com/browse/ACM-14707