### PR TITLE
Allow config-policy secrets access in hosted mode

### DIFF
--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cluster_role.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cluster_role.yaml
@@ -71,13 +71,14 @@ rules:
   - update
 - apiGroups:
   - ""
-  resourceNames:
-  - policy-encryption-key
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
+  - patch
+  - update
   - watch
 {{- else }}
 - apiGroups:


### PR DESCRIPTION
Previously, the only secret the config-policy-controller would need is the policy-encryption key. Now, with standalone hub templating, it needs access to any secrets in the cluster namespace. In hosted mode, those permissions need to be specially configured.

Refs:
 - https://issues.redhat.com/browse/ACM-16091