### PR TITLE
Fix: add missing `resources` key to values.yaml

### DIFF
--- a/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
@@ -51,10 +51,11 @@ prometheus:
 global:
   resourceRequirements:
     - containerIDRegex: ^.+:.+:.+$
-      requests:
-        memory: 128Mi
-      limits:
-        memory: 512Mi
+      resources:
+        requests:
+          memory: 128Mi
+        limits:
+          memory: 512Mi
   imagePullPolicy: IfNotPresent
   imagePullSecret: open-cluster-management-image-pull-credentials
   imageOverrides:

--- a/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
@@ -48,10 +48,11 @@ prometheus:
 global:
   resourceRequirements:
     - containerIDRegex: ^.+:.+:.+$
-      requests:
-        memory: 64Mi
-      limits:
-        memory: 512Mi
+      resources:
+        requests:
+          memory: 64Mi
+        limits:
+          memory: 512Mi
   imagePullPolicy: IfNotPresent
   imagePullSecret: open-cluster-management-image-pull-credentials
   imageOverrides:

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -366,6 +366,10 @@ var _ = Describe("Test framework deployment", Ordered, func() {
 	It("should create a framework deployment with resource requirements on the managed cluster",
 		func(ctx SpecContext) {
 			deploymentConfigTests := map[string]map[string]interface{}{
+				"../resources/addondeploymentconfig_empty.yaml": {
+					"requests": map[string]interface{}{"memory": "64Mi"},
+					"limits":   map[string]interface{}{"memory": "512Mi"},
+				},
 				"../resources/addondeploymentconfig_resourceRequirements_individual.yaml": {
 					"requests": map[string]interface{}{"memory": "50Mi"},
 					"limits":   map[string]interface{}{"memory": "100Mi"},

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -222,6 +222,10 @@ var _ = Describe("Test config-policy-controller deployment", Ordered, func() {
 	It("should create a config-policy-controller deployment with resource requirements on the managed cluster",
 		func(ctx SpecContext) {
 			deploymentConfigTests := map[string]map[string]interface{}{
+				"../resources/addondeploymentconfig_empty.yaml": {
+					"requests": map[string]interface{}{"memory": "128Mi"},
+					"limits":   map[string]interface{}{"memory": "512Mi"},
+				},
 				"../resources/addondeploymentconfig_resourceRequirements_individual.yaml": {
 					"requests": map[string]interface{}{"memory": "75Mi"},
 					"limits":   map[string]interface{}{"memory": "150Mi"},

--- a/test/resources/addondeploymentconfig_empty.yaml
+++ b/test/resources/addondeploymentconfig_empty.yaml
@@ -1,0 +1,6 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: addon-default-placement
+  namespace: open-cluster-management
+spec: {}


### PR DESCRIPTION
Without it, the default resources weren't getting populated.

Followup to:
- #197 