### PR TITLE
Use informers for faster lookups

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -181,7 +181,19 @@ rules:
   - update
 - apiGroups:
   - rbac.authorization.k8s.io
+  resourceNames:
+  - open-cluster-management:governance-standalone-hub-templating
   resources:
+  - clusterrolebindings
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
   - clusterroles
   - rolebindings
   verbs:

--- a/main.go
+++ b/main.go
@@ -57,6 +57,8 @@ import (
 
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;update;patch;delete,resourceNames="open-cluster-management:policy-framework-hub";"open-cluster-management:config-policy-controller-hub";"open-cluster-management:governance-standalone-hub-templating"
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;update;patch;delete,resourceNames="open-cluster-management:governance-standalone-hub-templating"
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;update;patch;delete,resourceNames="open-cluster-management:policy-framework-hub";"open-cluster-management:config-policy-controller-hub";"open-cluster-management:governance-standalone-hub-templating"
 

--- a/pkg/addon/common.go
+++ b/pkg/addon/common.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/openshift/library-go/pkg/assets"
@@ -18,13 +17,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	"open-cluster-management.io/addon-framework/pkg/agent"
 	"open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
-	clusterv1client "open-cluster-management.io/api/client/cluster/clientset/versioned"
-	clusterv1informers "open-cluster-management.io/api/client/cluster/informers/externalversions"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -180,18 +176,6 @@ func GetAndAddAgent(
 	}
 
 	return nil
-}
-
-func GetManagedClusterClient(ctx context.Context, kubeConfig *rest.Config) (*clusterv1client.Clientset, error) {
-	clusterClient, err := clusterv1client.NewForConfig(kubeConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	clusterInformers := clusterv1informers.NewSharedInformerFactory(clusterClient, 10*time.Minute)
-	go clusterInformers.Cluster().V1().ManagedClusters().Informer().Run(ctx.Done())
-
-	return clusterClient, nil
 }
 
 // PolicyAgentAddon wraps the AgentAddon created from the addonfactory to override some behavior

--- a/pkg/addon/standalonetemplating/agent_addon.go
+++ b/pkg/addon/standalonetemplating/agent_addon.go
@@ -13,6 +13,7 @@ import (
 	"open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
+	clusterv1client "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
 	policyaddon "open-cluster-management.io/governance-policy-addon-controller/pkg/addon"
@@ -35,7 +36,8 @@ var agentPermissionFiles = []string{
 	"manifests/hubpermissions/rolebinding.yaml",
 }
 
-func getValues(_ *clusterv1.ManagedCluster,
+func getValues(
+	_ *clusterv1.ManagedCluster,
 	addon *addonapiv1alpha1.ManagedClusterAddOn,
 ) (addonfactory.Values, error) {
 	values := addonfactory.Values{}
@@ -46,7 +48,7 @@ func getValues(_ *clusterv1.ManagedCluster,
 	return values, nil
 }
 
-func getAgentAddon(ctx context.Context, controllerContext *controllercmd.ControllerContext) (agent.AgentAddon, error) {
+func getAgentAddon(controllerContext *controllercmd.ControllerContext) (agent.AgentAddon, error) {
 	registrationOption := policyaddon.NewRegistrationOption(
 		controllerContext,
 		addonName,
@@ -59,7 +61,7 @@ func getAgentAddon(ctx context.Context, controllerContext *controllercmd.Control
 		return nil, fmt.Errorf("failed to retrieve addon client: %w", err)
 	}
 
-	clusterClient, err := policyaddon.GetManagedClusterClient(ctx, controllerContext.KubeConfig)
+	clusterClient, err := clusterv1client.NewForConfig(controllerContext.KubeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize a managed cluster client: %w", err)
 	}
@@ -99,9 +101,9 @@ func (sa *StandaloneAgentAddon) Manifests(
 }
 
 func GetAndAddAgent(
-	ctx context.Context, mgr addonmanager.AddonManager, controllerContext *controllercmd.ControllerContext,
+	_ context.Context, mgr addonmanager.AddonManager, controllerContext *controllercmd.ControllerContext,
 ) error {
-	agentAddon, err := getAgentAddon(ctx, controllerContext)
+	agentAddon, err := getAgentAddon(controllerContext)
 	if err != nil {
 		return fmt.Errorf("failed getting the %v agent addon: %w", addonName, err)
 	}


### PR DESCRIPTION
    Use informers for MC and MCAO lookups
    
    In a scale test, it was found that this controller was falling behind
    when it needed to reconcile thousands of clusters. The main cause was
    the new GET request when reconciling the config-policy-controller addon,
    since it needs to check whether the governance-standalone-hub-templating
    addon for that managed cluster exists. At heavy loads, this caused each
    reconcile to take approximately 0.2 seconds because of rate-limiting.
    
    That GET request, as well as a similar requests for ManagedClusters done
    by multiple addons in hosted mode, will now use informers to use a local
    cache of those resources. These "requests" are now basically instant.
    
    Refs:
     - https://issues.redhat.com/browse/ACM-18029

This PR also includes a small update to RBAC that was missed previously.