### PR TITLE
Stop disabling operator-policy on non-OCP clusters

### DIFF
--- a/pkg/addon/configpolicy/agent_addon.go
+++ b/pkg/addon/configpolicy/agent_addon.go
@@ -90,7 +90,11 @@ func (cpv *configPolicyUserValues) setOperatorPolicyDisabled(value string) error
 		return err
 	}
 
-	cpv.OperatorPolicy.Disabled = valBool
+	if cpv.OperatorPolicy != nil {
+		cpv.OperatorPolicy.Disabled = valBool
+	} else {
+		cpv.OperatorPolicy = &operatorPolicy{Disabled: valBool}
+	}
 
 	return nil
 }
@@ -122,8 +126,6 @@ func getValuesFromAnnotations(
 		// Configure OperatorPolicy based on the cluster's OpenShift version
 		if cluster.Labels["openshiftVersion-major"] == "4" {
 			userValues.OperatorPolicy.DefaultNamespace = "openshift-operators"
-		} else {
-			userValues.OperatorPolicy.Disabled = true
 		}
 
 		if err := userValues.CommonValues.SetCommonValuesFromAnnotations(addon); err != nil {

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -472,7 +472,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 							g.Expect(args).To(ContainElement("--log-encoder=console"))
 							g.Expect(args).To(ContainElement("--evaluation-concurrency=2"))
 							g.Expect(args).To(ContainElement("--client-max-qps=30"))
-							g.Expect(args).NotTo(ContainElement("--enable-operator-policy=true"))
+							g.Expect(args).To(ContainElement("--enable-operator-policy=true"))
 						}
 					}
 				}, 180, 10).Should(Succeed())


### PR DESCRIPTION
Instead of needing to enable operator-policy on non-OCP clusters, users will now need to disable operator-policy if it's causing problems on a cluster. This should help in cases where the proper labels are not yet present on a managed cluster.

Refs:
 - https://issues.redhat.com/browse/ACM-30555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration now safely initializes operator policy when previously uninitialized.
  * Adjusted OpenShift handling so default namespace is set for non-OpenShift 4 clusters without forcing operator policy disabled.
* **Tests**
  * Updated end-to-end test expectations to reflect operator policy enablement flag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-cluster-management-io/governance-policy-addon-controller/pull/283)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->