### PR TITLE
Add option to orphan cluster namespace

### DIFF
--- a/pkg/addon/policyframework/agent_addon.go
+++ b/pkg/addon/policyframework/agent_addon.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,6 +38,7 @@ type policyFrameworkUserValues struct {
 
 	SyncPoliciesOnMulticlusterHub bool `json:"syncPoliciesOnMulticlusterHub,string,omitempty"`
 	OnMulticlusterHub             bool `json:"onMulticlusterHub,string,omitempty"`
+	OrphanClusterNamespace        bool `json:"orphanClusterNamespace,string,omitempty"`
 }
 
 var (
@@ -132,11 +134,25 @@ func getValuesFromCustomizedVariableValues(config addonapiv1beta1.AddOnDeploymen
 		log.Error(err, "error setting common addon values from customized variables")
 	}
 
-	variableToFuncMap := map[string]func(*policyFrameworkUserValues, string){}
+	variableToFuncMap := map[string]func(string) error{
+		"orphanClusterNamespace": func(value string) error {
+			valBool, err := strconv.ParseBool(value)
+			if err != nil {
+				return err
+			}
+
+			userValues.OrphanClusterNamespace = valBool
+
+			return nil
+		},
+	}
 
 	for key, value := range userValuesMap {
 		if fn, ok := variableToFuncMap[key]; ok {
-			fn(&userValues, value)
+			err := fn(value)
+			if err != nil {
+				log.Error(err, "error setting customized variable", "variable", key, "value", value)
+			}
 		} else {
 			log.Error(fmt.Errorf("unknown customized variable: %s", key), "unknown customized variable")
 		}

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/namespace.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/namespace.yaml
@@ -5,4 +5,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: "{{ .Values.clusterName }}"
+  {{- if .Values.orphanClusterNamespace }}
+  annotations:
+    "addon.open-cluster-management.io/deletion-orphan": ""
+  {{- end }}
 {{- end }}

--- a/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
@@ -4,6 +4,7 @@ fullnameOverride: null
 nameOverride: null
 
 onMulticlusterHub: false
+orphanClusterNamespace: false
 
 org: open-cluster-management
 replicas: 1

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -23,6 +23,8 @@ const (
 	case1ClusterManagementAddOnCR        string = "../resources/framework_clustermanagementaddon_config.yaml"
 	case1CMAAddonWithInstallNs           string = "../resources/framework_cma_config_agentInstallNs.yaml"
 	case1CMAAddonWithCustomizedVars      string = "../resources/framework_cma_config_customizedVars.yaml"
+	case1CMAOrphanClusterNamespace       string = "../resources/framework_cma_config_orphanClusterNamespace.yaml"
+	case1AODCOrphanClusterNamespace      string = "../resources/addondeploymentconfig_orphan_cluster_namespace.yaml"
 	case1hubAnnotationMCAOCR             string = "../resources/framework_hub_annotation_addon_cr.yaml"
 	case1hubValuesMCAOCR                 string = "../resources/framework_hub_values_addon_cr.yaml"
 	case1DeploymentName                  string = "governance-policy-framework"
@@ -30,6 +32,7 @@ const (
 	case1MWName                          string = "addon-governance-policy-framework-deploy-0"
 	case1MWPatch                         string = "../resources/manifestwork_add_patch.json"
 	ocmPolicyNs                          string = "open-cluster-management-policies"
+	deletionOrphanAnnotationKey          string = "addon.open-cluster-management.io/deletion-orphan"
 )
 
 var _ = Describe("Test framework deployment", func() {
@@ -791,6 +794,52 @@ var _ = Describe("Test framework deployment", func() {
 			GetWithTimeoutClusterResource(ctx, cluster.clusterClient, gvrNamespace, cluster.clusterName, false, 15)
 		}
 	})
+
+	It("should leave the cluster namespace on the managed cluster when orphanClusterNamespace is configured",
+		func(ctx SpecContext) {
+			By("Creating the AddOnDeploymentConfig with orphanClusterNamespace")
+			Kubectl("apply", "-f", case1AODCOrphanClusterNamespace)
+			DeferCleanup(func() {
+				By("Deleting the AddOnDeploymentConfig for orphanClusterNamespace")
+				Kubectl("delete", "-f", case1AODCOrphanClusterNamespace, "--timeout=15s")
+			})
+
+			By("Applying the governance-policy-framework ClusterManagementAddOn to use the AddOnDeploymentConfig")
+			Kubectl("apply", "-f", case1CMAOrphanClusterNamespace)
+
+			for i, cluster := range managedClusterList[1:] {
+				Expect(cluster.clusterType).To(Equal("managed"))
+
+				logPrefix := cluster.clusterType + " " + cluster.clusterName + ": "
+				By(logPrefix + "deploying the framework managedclusteraddon")
+				Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+				checkContainersAndAvailability(ctx, cluster, i+1)
+
+				By(logPrefix + "deleting the managedclusteraddon")
+				Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, "--timeout=180s")
+				deploy := GetWithTimeout(
+					ctx, cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
+				)
+				Expect(deploy).To(BeNil())
+
+				By(logPrefix + "checking the managed cluster namespace remains after the addon is removed")
+				Consistently(func() *unstructured.Unstructured {
+					return GetWithTimeoutClusterResource(
+						ctx, cluster.clusterClient, gvrNamespace, cluster.clusterName, true, 15)
+				}, 30, 5).Should(Not(BeNil()))
+
+				ctxNS, cancelNS := context.WithTimeout(ctx, 15*time.Second)
+				defer cancelNS()
+
+				By(logPrefix + "cleaning up the orphaned cluster namespace")
+				err := cluster.clusterClient.Resource(gvrNamespace).Delete(
+					ctxNS, cluster.clusterName, metav1.DeleteOptions{},
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				GetWithTimeoutClusterResource(ctx, cluster.clusterClient, gvrNamespace, cluster.clusterName, false, 120)
+			}
+		})
 
 	It("should deploy with startupProbes or initialDelaySeconds depending on version", func(ctx SpecContext) {
 		for i, cluster := range managedClusterList[1:] {

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -26,7 +26,6 @@ const (
 	case2PodSelector                     string = "app=config-policy-controller"
 	case2OpenShiftClusterClaim           string = "../resources/openshift_cluster_claim.yaml"
 	policyCrdName                        string = "policies.policy.open-cluster-management.io"
-	deletionOrphanAnnotationKey          string = "addon.open-cluster-management.io/deletion-orphan"
 )
 
 func verifyConfigPolicyDeployment(

--- a/test/resources/addondeploymentconfig_orphan_cluster_namespace.yaml
+++ b/test/resources/addondeploymentconfig_orphan_cluster_namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: addon-orphan-cluster-namespace
+  namespace: open-cluster-management
+spec:
+  customizedVariables:
+    - name: orphanClusterNamespace
+      value: "true"

--- a/test/resources/framework_cma_config_orphanClusterNamespace.yaml
+++ b/test/resources/framework_cma_config_orphanClusterNamespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: governance-policy-framework
+spec:
+  supportedConfigs:
+  - group: addon.open-cluster-management.io
+    resource: addondeploymentconfigs
+    defaultConfig:
+      name: addon-orphan-cluster-namespace
+      namespace: open-cluster-management


### PR DESCRIPTION
Previously, the cluster namespace on the managed cluster used by the policy framework for copies of Policies would always be removed when the addon is removed (including when the whole cluster was removed from being managed by OCM). Now, if users want to preserve the namespace, they can set the `orphanClusterNamespace` custom variable in their AddOnDeploymentConfig.

Refs:
 - https://issues.redhat.com/browse/ACM-30557

Assisted-by: Cursor, claude-4.6-opus-high

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `orphanClusterNamespace` configuration, enabling cluster namespaces to remain on managed clusters when add-ons are uninstalled.

* **Tests**
  * Added end-to-end test coverage to validate orphan cluster namespace behavior and configuration handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-cluster-management-io/governance-policy-addon-controller/pull/284)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->